### PR TITLE
Initial commit: virus_total.yml

### DIFF
--- a/.github/workflows/virus_total.yml
+++ b/.github/workflows/virus_total.yml
@@ -1,0 +1,18 @@
+name: VirusTotal
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  virustotal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: VirusTotal Scan
+        uses: crazy-max/ghaction-virustotal@v3
+        with:
+          vt_api_key: ${{ secrets.VIRUSTOTAL_API_KEY }}
+          github_token: ${{ secrets.ACTIONS_TOKEN }}
+          update_release_body: true
+          files: |
+            SubSearch-*.zip


### PR DESCRIPTION
Reason:
Windows defender tends to false flag the .exe
From my testing as Trojan:Win32/Wacatac.H!ml

PSA:
Always do your own scans and don't blindly trust random people :)