### PR TITLE
Things for PyPi

### DIFF
--- a/.github/workflows/push_tags.yml
+++ b/.github/workflows/push_tags.yml
@@ -70,7 +70,10 @@ jobs:
           pip install -r docs/requirements.txt
       # copy source code to workflows
       - name: Copy source to .github/workflows/subsearch
-        run: cp -r ./src/subsearch/ .github/workflows/subsearch/
+        run: |
+          cp -r ./src/subsearch/ .github/workflows/subsearch/
+          rm .github\workflows\subsearch\__init__.py
+          rm .github\workflows\subsearch\__main__.py
       # build the executable and manually add sv_ttk otherwise it wont be included
       - name: Build executable
         run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,34 @@
+name: PyPi
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: PyPI Upload
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "*"
+
+      - name: Install latest pip, build, twine
+        run: |
+          python -m pip install --upgrade --disable-pip-version-check pip
+          python -m pip install --upgrade build twine
+      - name: Build wheel and source distributions
+        run: |
+          python -m build
+      - name: Upload to PyPI via Twine
+        env:
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          twine upload --verbose -u '__token__' dist/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include docs\requirements.txt
+include docs\dev_requirements.txt
 include assets\*.png
 include src\subsearch\data\*.json
 include src\subsearch\assets\buttons\*.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42.0", "wheel"]
+requires = ["setuptools>=63.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,13 +18,13 @@ package_dir =
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    setuptools
-    beautifulsoup4
-    cloudscraper
-    num2words
-    requests
-    lxml
-    sv-ttk
+    setuptools>=63.2
+    beautifulsoup4>=4.11
+    cloudscraper>=1.2
+    num2words>=0.5
+    requests>=2.28
+    lxml>=4.9
+    sv-ttk>=1
 python_requires = >=3.10
 zip_safe = no
 
@@ -37,6 +37,9 @@ exclude =
     subsearch.test*
     subsearch.*.log
 where = src
+[options.entry_points]
+console_scripts =
+    subsearch = subsearch.__main__:main
 
 [options.extras_require]
 testing =

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,5 @@
 from setuptools import setup
 
-
-def read_file(fname):
-    with open(fname, "r") as f:
-        return f.read()
-
-
-requirements = read_file("docs/requirements.txt").strip().split()
-
-
 setup(
-    install_requires=requirements,
-    package_data={"": ["requirements.text", "*.png", "*.ico"]},
+    package_data={"": ["requirements.text", "dev_requirements.text", "*.png", "*.ico"]},
 )

--- a/src/subsearch/__init__.py
+++ b/src/subsearch/__init__.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+PACKAGEPATH = os.path.abspath(os.path.dirname(__file__))
+HOMEPATH = os.path.dirname(PACKAGEPATH)
+
+sys.path.append(HOMEPATH)
+sys.path.append(PACKAGEPATH)

--- a/src/subsearch/__main__.py
+++ b/src/subsearch/__main__.py
@@ -1,0 +1,53 @@
+import sys
+
+from gui import widget_settings
+from utils import raw_registry, search
+
+
+def main() -> None:
+    r"""
+    Usages: subsearch [OPTIONS]
+
+    Options:
+        --settings                                  Open the GUI settings menu
+
+        --registry-key [add, del]                   Edit the registry
+                                                    add: adds the context menu  / replaces the context menu with default values
+                                                    del: deletes the context menu
+                                                    e.g: subsearch --registry-key add
+
+        --help                                      Prints usage information
+
+        --search [release]                          Search for subtitles and download to current working directory
+                                                    release: release.ext
+                                                    e.g subsearch --search foo.bar.the.movie.2021.1080p.web-foobar.mkv
+    """
+    if sys.argv[-1].endswith("subsearch"):
+        print(main.__doc__)
+        return
+    else:
+        for num, arg in enumerate(sys.argv[1:], 1):
+            if arg.startswith("--settings"):
+                widget_settings.show_widget()
+                break
+            elif arg.startswith("--registry-key") or arg.startswith("--add-key"):
+                if sys.argv[num + 1] == "add":
+                    raw_registry.write_all_valuex()
+                    break
+                elif sys.argv[num + 1] == "del":
+                    raw_registry.remove_context_menu()
+                    break
+            elif arg.startswith("--help"):
+                print(main.__doc__)
+                break
+            elif arg.startswith("--search"):
+                video_file = sys.argv[num + 1]
+                search.run_search(video_file)
+                break
+            elif len(sys.argv[1:]) == num:
+                print("Invalid argument")
+                print(main.__doc__)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- requirements moved out from setup.py
- console_script added, subsearch = subsearch.__main__:main
- dev_requirements.txt now in MANIFEST.in
- pypi upload workflow added

PyPi:
- subsearch can soon be installed with `pip install subsearch`
afterwards ran from the terminal with subsearch followed by:
- --settings 
- --registry-key [add, del] 
- --help                                 
- --search [release]