### PR TITLE
Fix: pip install subsearch fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,33 +79,23 @@ Add the context-menu
 
 `subsearch --registry-key add`
 
-Access GUI settings menu
-
-`subsearch --settings`
-
-For more options
-
 Right-click on a video file that ends with [extensions](#file_ext) and press SubSearch to search
 
-`subsearch --help`
+More options
 
 ```
+Usages: subsearch [OPTIONS]
 
-    Usages: subsearch [OPTIONS]
+Options:
+    --settings                                  Open the GUI settings menu
 
-    Options:
-        --settings                                  Open the GUI settings menu
+    --registry-key [add, del]                   Edit the registry
+                                                add: adds the context menu  / replaces the context menu with default values
+                                                del: deletes the context menu
+                                                e.g: subsearch --registry-key add
 
-        --registry-key [add, del]                   Edit the registry
-                                                    add: adds the context menu  / replaces the context menu with default values
-                                                    del: deletes the context menu
-                                                    e.g: subsearch --registry-key add
+    --help                                      Prints usage information
 
-        --help                                      Prints usage information
-
-        --search [release]                          Search for subtitles and download to current working directory
-                                                    release: release.ext
-                                                    e.g subsearch --search foo.bar.the.movie.2021.1080p.web-foobar.mkv
 ```
 
 ### Source <a name = "src"></a>

--- a/src/subsearch/__main__.py
+++ b/src/subsearch/__main__.py
@@ -1,7 +1,7 @@
 import sys
 
 from gui import widget_settings
-from utils import raw_registry, search
+from utils import raw_registry
 
 
 def main() -> None:
@@ -17,10 +17,6 @@ def main() -> None:
                                                     e.g: subsearch --registry-key add
 
         --help                                      Prints usage information
-
-        --search [release]                          Search for subtitles and download to current working directory
-                                                    release: release.ext
-                                                    e.g subsearch --search foo.bar.the.movie.2021.1080p.web-foobar.mkv
     """
     if sys.argv[-1].endswith("subsearch"):
         print(main.__doc__)
@@ -32,7 +28,7 @@ def main() -> None:
                 break
             elif arg.startswith("--registry-key") or arg.startswith("--add-key"):
                 if sys.argv[num + 1] == "add":
-                    raw_registry.write_all_valuex()
+                    raw_registry.add_context_menu()
                     break
                 elif sys.argv[num + 1] == "del":
                     raw_registry.remove_context_menu()
@@ -40,10 +36,10 @@ def main() -> None:
             elif arg.startswith("--help"):
                 print(main.__doc__)
                 break
-            elif arg.startswith("--search"):
-                video_file = sys.argv[num + 1]
-                search.run_search(video_file)
-                break
+            # elif arg.startswith("--search"):
+            #     video_file = sys.argv[num + 1]
+            #     search.run_search(video_file)
+            #     break
             elif len(sys.argv[1:]) == num:
                 print("Invalid argument")
                 print(main.__doc__)

--- a/src/subsearch/subsearch.py
+++ b/src/subsearch/subsearch.py
@@ -1,10 +1,11 @@
+import os
 import sys
 
 from gui import widget_settings
 from utils import current_user, local_paths, raw_config, raw_registry, search
 
 
-def main(enter: str = None) -> None:
+def main() -> None:
     """
     main function for subsearch
 
@@ -15,14 +16,19 @@ def main(enter: str = None) -> None:
         if sys.argv[1] == "subsearch.py", enter = "--settings":
 
     """
+
+    for ext in raw_config.get("file_ext"):
+        if sys.argv[-1].endswith(ext):
+            file_path = sys.argv[-1]
+            index = file_path.rfind("\\")
+            dir_path = file_path[0:index]
+            os.chdir(dir_path)
+
     if current_user.got_key() is False:
         raw_config.set_default_json()
         raw_registry.add_context_menu()
-    if sys.argv[-1].endswith("subsearch.py"):
-        enter = "--settings"
-    if local_paths.get_path("cwd") == local_paths.get_path("root") or enter == "--settings":
+    if local_paths.get_path("cwd") == local_paths.get_path("root") or sys.argv[-1].endswith("subsearch.py"):
         widget_settings.show_widget()
-
     elif local_paths.get_path("cwd") != local_paths.get_path("root"):
         search.run_search(sys.argv[-1])
 

--- a/src/subsearch/utils/raw_registry.py
+++ b/src/subsearch/utils/raw_registry.py
@@ -86,8 +86,8 @@ def get_command_value() -> str:
         # import_sys = "import sys; media_file_path = sys.argv[-1];"
         set_title = "import ctypes; ctypes.windll.kernel32.SetConsoleTitleW('SubSearch');"
         # gets the path of the root directory of subsearch
-        set_wd = f"import os; working_path = os.getcwd(); os.chdir('{local_paths.get_path('root')}');"
-        import_main = "import subsearch; os.chdir(working_path); subsearch.main()"
+        set_wd = f"import os; os.chdir(r'{local_paths.get_path('root')}');"
+        import_main = "import subsearch; subsearch.main()"
         if show_terminal == "True":
             value = f'{python_path}\python.exe -c "{set_title} {set_wd} {import_main}" %1'
         if show_terminal == "False":


### PR DESCRIPTION
Should now work


Fixes:
 - os.chdir('{local_paths.get_path('root')}'); -> os.chdir(r'{local_paths.get_path('root')}');
 added r so no escape characters

- working_path = os.getcwd()
would become the terminal cwd, now the directory change happens inside subsearch.py