### PR TITLE
Fix virustotal no assets were found

### DIFF
--- a/.github/workflows/virustotal.yml
+++ b/.github/workflows/virustotal.yml
@@ -15,4 +15,4 @@ jobs:
           github_token: ${{ secrets.ACTIONS_TOKEN }}
           update_release_body: true
           files: |
-            SubSearch-${{ github.ref_name }}-win-x64.zip
+            Subsearch-${{ github.ref_name }}-win-x64.zip


### PR DESCRIPTION
```
SubSearch-${{ github.ref_name }}-win-x64.zip -> Subsearch-${{ github.ref_name }}-win-x64.zip
```