### PR TITLE
Support for pre-releases

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: Add labels & assignees to PR's
 
 on:
   pull_request:
-    types: [opened, unassigned, unlabeled]
+    types: [opened]
   pull_request_target:
     types: [opened, unassigned, unlabeled]
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,3 @@
-# feat
 name: Add labels & assignees to PR's
 
 on:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,8 @@
 name: Add labels & assignees to PR's
 
 on:
+  pull_request:
+    types: [opened, unassigned, unlabeled]
   pull_request_target:
     types: [opened, unassigned, unlabeled]
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: Add labels & assignees to PR's
 
 on:
   pull_request_target:
-    types: [unassigned, unlabeled]
+    types: [opened, unassigned, unlabeled]
 
 jobs:
   pr-labeler:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,10 +128,12 @@ jobs:
         with:
           body: ${{steps.github_release.outputs.changelog}}
           token: ${{ secrets.ACTIONS_TOKEN }}
+          prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-b') || contains(github.ref, '-a') }}
           files: |
             Subsearch-${{ github.ref_name }}-win-x64.zip
 
   pypi-upload:
+    if: ${{ !contains(github.ref, '-') }}
     name: PyPI Upload
     needs: versioning
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.10.0", "3.10.6"]
+        python-version: ["3.10.0"]
 
     steps:
       - uses: actions/checkout@v2

--- a/scripts/set__version__.py
+++ b/scripts/set__version__.py
@@ -9,7 +9,7 @@ file_path = f"{cwd}/src/subsearch/data/__version__.py"
 
 with open(file_path, "r+") as f:
     file_content = f.read()  # open file and read the content
-    pattern = re.compile("([0-9]*\.[0-9]*\.[0-9]*)")  # find version number, https://regex101.com/r/alA3K9/1
+    pattern = re.compile("(\d*\.\d*\.\d*-rc\d*)|(\d*\.\d*\.\d*)")  # find version number, https://regex101.com/r/alA3K9/1
     new_content = pattern.sub(version, file_content)  # replace current version number with new version number
     f.seek(0)
     f.truncate()

--- a/src/subsearch/gui/widget_settings.py
+++ b/src/subsearch/gui/widget_settings.py
@@ -723,24 +723,24 @@ class CheckForUpdates(tk.Frame):
 
     def button_check(self, event):
         self.string_var.set(f"Searching for updates...")
-        value, release_type = updates.is_new_version_available()
-        latest_version = updates.check_for_updates()
+        value, rc = updates.is_new_version_avail()
+        latest_version = updates.latest_version_str()
+        if value and rc:
+            self.string_var.set(f"New release candidate available")
+        elif value and rc is False:
+            self.string_var.set(f"New stable release available")
+        else:
+            self.string_var.set(f"You are up to date")
+
         if value:
-            self.string_var.set(f"New version available!")
             tools.Create.button(
                 self,
-                text=f"Get {latest_version}",
+                text=f"Get v{latest_version}",
                 height=2,
                 width=24,
                 bind_to=self.button_download,
             )
 
-        if value is False and release_type is None:
-            self.string_var.set(f"You are up to date!")
-        elif value is False and release_type is None:
-            self.string_var.set(f"New {release_type} update available")
-        elif value is False and release_type is not None:
-            self.string_var.set(f"Branch ahead of main branch")
 
     def button_download(self, event):
         webbrowser.open("https://github.com/vagabondHustler/SubSearch/releases")

--- a/src/subsearch/gui/widget_settings.py
+++ b/src/subsearch/gui/widget_settings.py
@@ -741,7 +741,6 @@ class CheckForUpdates(tk.Frame):
                 bind_to=self.button_download,
             )
 
-
     def button_download(self, event):
         webbrowser.open("https://github.com/vagabondHustler/SubSearch/releases")
 


### PR DESCRIPTION
```
workflows steps in release.yml does not publish to pypi if the tags contain - e.g -rc1

regex now finds -rc plus int set__version in /scripts

class CheckForUpdates 
in module widget_settings can now read the version if it's a pre-release

moduile update in subsearch/utils 
is now re-written with new functions and re expressions
```