### PR TITLE
Feature differentiate between rc, beta, alpha

### DIFF
--- a/src/subsearch/gui/widget_settings.py
+++ b/src/subsearch/gui/widget_settings.py
@@ -723,11 +723,16 @@ class CheckForUpdates(tk.Frame):
 
     def button_check(self, event):
         self.string_var.set(f"Searching for updates...")
-        value, rc = updates.is_new_version_avail()
+        value, pre = updates.is_new_version_avail()
         latest_version = updates.get_latest_version(semantic=True)
-        if value and rc:
+        if value and pre:
+            if '-rc' in latest_version:
             self.string_var.set(f"New release candidate available")
-        elif value and rc is False:
+            elif "-alpha"in latest_version:
+                self.string_var.set(f"New alpha release available")
+            elif "-beta"in latest_version:
+                self.string_var.set(f"New beta release available")
+        elif value and pre is False:
             self.string_var.set(f"New stable release available")
         else:
             self.string_var.set(f"You are up to date")


### PR DESCRIPTION
```
New func `define_pre_release_worth` in updates.py
  Add int to float if rc, beta or alpha is found in semantic version
  rc = 3, beta = 2, alpha = 1
  x.x.x-beta.1 would equal float(2.1)

New `regex` expression for semantic version
New `regex` expression for float version

Update func `get_current_version` can return semantic version
  __version__ is already semantic but updated for consistency

Update module widget_settings.py
  tells user if the update is stable, release candidate, beta or alpha
modified:   src/subsearch/gui/widget_settings.py
modified:   src/subsearch/utils/updates.py
```