### PR TITLE
Chore fix SetuptoolsDeprecationWarning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.10.0
 envlist = py310
-isolated_build = true
+
 
 [gh-actions]
 python =
@@ -14,4 +14,5 @@ deps =
     -r{toxinidir}/docs/dev_requirements.txt
 commands =
     pytest --basetemp={envtmpdir}
+    isolated_build = true
     


### PR DESCRIPTION
SetuptoolsDeprecationWarning: 
The arguments ['--formats=gztar'] were given via `--global-option`.
Please use `--build-option` instead, `--global-option` is reserved to flags like `--verbose` or `--quiet`.