### PR TITLE
Toggle rename_best_match, pct slider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,8 +148,6 @@ desktop.ini
 
 # Subsearch
 src/*test*
-src/*/__subsearch__*.*
-src/__subsearch__*.*
 src/*language
 src/*.zip
 src/*.srt

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Install package locally
 Code <a name = "code"></a>
 
 ```
-from subsearch import Subsearch
+from subsearch import __subsearch__
 from subsearch.utils.raw_config import get_config, set_config
 
 
@@ -106,11 +106,11 @@ def main() -> None:
     config = get_config()
     config["providers"]["opensubtitles_hash"] = False
     set_config(config)
-    ss = Subsearch()
-    ss.subscene_scrape()
-    ss.opensubtitles_scrape()
-    ss.process_files()
-    ss.end()
+    app = __subsearch__.Subsearch()
+    app.provider_opensubtitles()
+    app.provider_subscene()
+    app.process_files()
+    app.on_exit()
 
 
 if __name__ == "__main__":

--- a/src/subsearch/__init__.py
+++ b/src/subsearch/__init__.py
@@ -1,19 +1,9 @@
-import ctypes
 import os
 import sys
-import time
 
-from subsearch.data import __version__, __video__
+from subsearch import __subsearch__
 from subsearch.gui import widget_menu
-from subsearch.providers import opensubtitles, subscene
-from subsearch.utils import (
-    current_user,
-    file_manager,
-    log,
-    raw_config,
-    raw_registry,
-    string_parser,
-)
+from subsearch.utils import raw_registry
 
 PACKAGEPATH = os.path.abspath(os.path.dirname(__file__))
 HOMEPATH = os.path.dirname(PACKAGEPATH)
@@ -21,134 +11,41 @@ sys.path.append(HOMEPATH)
 sys.path.append(PACKAGEPATH)
 
 
-class Subsearch:
+class Subsearch(__subsearch__.Steps):
     def __init__(self) -> None:
         """
         Setup and gather all available parameters
         """
-        self.start = time.perf_counter()
-        ctypes.windll.kernel32.SetConsoleTitleW(f"SubSearch - {__version__}")
-        if current_user.got_key() is False:
-            raw_config.set_default_json()
-            raw_registry.add_context_menu()
-        self.show_terminal = False if current_user.check_is_exe() else raw_config.get_config_key("show_terminal")
-        self.providers = raw_config.get_config_key("providers")
+        __subsearch__.Steps.__init__(self)
 
-        self.file_exist = True if __video__.name is not None else False
-        self.current_language = raw_config.get_config_key("current_language")
-        self.languages = raw_config.get_config_key("languages")
-        self.subtitle_type = raw_config.get_config_key("subtitle_type")
-        self.pct = raw_config.get_config_key("percentage")
-        self.show_dl_win = raw_config.get_config_key("show_download_window")
-        self.user_parameters = raw_config.UserParameters(
-            current_language=self.current_language,
-            hearing_impaired=self.subtitle_type["hearing_impaired"],
-            non_hearing_impaired=self.subtitle_type["non_hearing_impaired"],
-            pct=self.pct,
-            show_dl_window=self.show_dl_win,
-        )
-        if self.file_exist:
-            self.file_hash = file_manager.get_hash(__video__.path)
-            self.parameters = string_parser.get_parameters(
-                __video__.name, self.file_hash, self.current_language, self.languages
-            )
-            log.parameters(self.parameters, self.user_parameters)
-            if " " in __video__.name:
-                log.output("[Warning: Filename contains spaces]")
-        if self.file_exist is False:
-            widget_menu.open_tab("search")
-            return None
-
-    def opensubtitles_scrape(self) -> None:
+    def provider_opensubtitles(self) -> None:
         """
         Scrape on opensubtitles by filehash
         """
-        if self.languages[self.current_language] == "N/A":
-            log.output("\n[Searching on opensubtitles]")
-            log.output(f"{self.current_language} not supported on opensubtitles\n")
-            self.opensubtitles_hash = None
-            self.opensubtitles_rss = None
-            self.opensubtitles_sorted_list = []
-            return
-        if self.file_exist and (self.providers["opensubtitles_hash"] or self.providers["opensubtitles_rss"]):
-            _opensubtitles = opensubtitles.OpenSubtitles(self.parameters, self.user_parameters)
-            if self.providers["opensubtitles_hash"] and self.file_hash is not None:
-                log.output("\n[Searching on opensubtitles - hash]")
-                self.opensubtitles_hash = _opensubtitles.parse_hash()
-            if self.providers["opensubtitles_rss"]:
-                log.output("\n[Searching on opensubtitles - rss]")
-                self.opensubtitles_rss = _opensubtitles.parse_rss()
-            self.opensubtitles_sorted_list = _opensubtitles.sorted_list()
+        self._provider_opensubtitles()
 
-    def subscene_scrape(self) -> None:
+    def provider_subscene(self) -> None:
         """
         Scrape subscene from parsing filename of the video
         """
-        if self.file_exist and self.providers["subscene"]:
-            log.output("\n[Searching on subscene - title]")
-            _subscene = subscene.Subscene(self.parameters, self.user_parameters)
-            self.subscene = _subscene.parse()
-            self.subscene_sorted_list = _subscene.sorted_list()
-        else:
-            self.subscene = None
+        self._provider_subscene()
 
     def process_files(self) -> None:
         """
         Download zip files containing the .srt files, extract, rename and clean up tmp files
         """
-        os_hash_dls = 0
-        os_rss_dls = 0
-        ss_dls = 0
-        if self.file_exist is False:
-            return None
+        self._download_files()
+        self._not_downloaded()
+        self._clean_up()
 
-        if self.providers["opensubtitles_hash"] and self.opensubtitles_hash is not None:
-            log.output("\n[Downloading from opensubtitles - hash]")
-            for item in self.opensubtitles_hash:
-                os_hash_dls = file_manager.download_subtitle(item)
-                log.output("\n")
-
-        if self.providers["opensubtitles_rss"] and self.opensubtitles_rss is not None:
-            log.output("\n[Downloading from opensubtitles - rss]")
-            for item in self.opensubtitles_rss:
-                os_rss_dls = file_manager.download_subtitle(item)
-
-        if self.providers["subscene"] and self.subscene is not None:
-            log.output("\n[Downloading from subscene]")
-            for item in self.subscene:
-                ss_dls = file_manager.download_subtitle(item)
-
-        total_dls = os_hash_dls + os_rss_dls + ss_dls
-        if self.show_dl_win and total_dls == 0:
-            not_downloaded = list(self.opensubtitles_sorted_list)
-            not_downloaded.extend(x for x in self.subscene_sorted_list if x not in not_downloaded)
-            not_downloaded.sort(key=lambda x: x[0], reverse=True)
-            if len(not_downloaded) > 0:
-                tmp_file = file_manager.write_not_downloaded_tmp(__video__.directory, not_downloaded)
-                widget_menu.open_tab("download")
-                file_manager.clean_up(__video__.directory, tmp_file)
-
-        log.output("\n[Procsessing files]")
-        file_manager.extract_files(__video__.directory, ".zip")
-        file_manager.clean_up(__video__.directory, ".zip")
-        file_manager.clean_up(__video__.directory, ").nfo")
-        file_manager.rename_best_match(f"{self.parameters.release}.srt", __video__.directory, ".srt")
-
-    def end(self) -> None:
+    def pre_exit(self) -> None:
         """
         Stop pref counter, log elapsed time and keep the terminal open if show_terminal is True
         """
-        elapsed = time.perf_counter() - self.start
-        log.output(f"\nFinished in {elapsed} seconds")
-
-        if self.show_terminal and current_user.check_is_exe() is False:
-            try:
-                input("Ctrl + c or Enter to exit")
-            except KeyboardInterrupt:
-                pass
+        self._pre_exit()
 
 
-def con() -> None:
+def console() -> None:
     r"""
     Usages: subsearch [OPTIONS]
 
@@ -194,24 +91,24 @@ def con() -> None:
                 break
         elif arg.startswith("--help"):
             sys.argv.pop(num)  # pop argument
-            print(con.__doc__)
+            print(console.__doc__)
             break
         elif len(sys.argv[1:]) == num:
             print("Invalid argument")
-            print(con.__doc__)
+            print(console.__doc__)
 
 
 def main() -> None:
     for i in sys.argv:
         if i.startswith("--"):
-            con()
+            console()
             return None
 
-    step = Subsearch()
-    step.opensubtitles_scrape()
-    step.subscene_scrape()
-    step.process_files()
-    step.end()
+    app = Subsearch()
+    app.provider_opensubtitles()
+    app.provider_subscene()
+    app.process_files()
+    app.pre_exit()
 
 
 if __name__ == "__main__":

--- a/src/subsearch/__subsearch__.py
+++ b/src/subsearch/__subsearch__.py
@@ -1,0 +1,157 @@
+import ctypes
+import os
+import time
+
+from subsearch.data import __version__, __video__
+from subsearch.gui import widget_menu
+from subsearch.providers import opensubtitles, subscene
+from subsearch.utils import (
+    current_user,
+    file_manager,
+    log,
+    raw_config,
+    raw_registry,
+    string_parser,
+)
+
+
+class BaseInitializer:
+    def __init__(self):
+        self.current_language = raw_config.get_config_key("current_language")
+        self.languages = raw_config.get_config_key("languages")
+        self.percentage = raw_config.get_config_key("percentage")
+        self.rename_best_match = raw_config.get_config_key("rename_best_match")
+        self.show_download_window = raw_config.get_config_key("show_download_window")
+        self.show_terminal = raw_config.get_config_key("show_terminal")
+        subtitle_type = raw_config.get_config_key("subtitle_type")
+        self.hearing_impaired = subtitle_type["hearing_impaired"]
+        self.non_hearing_impaired = subtitle_type["non_hearing_impaired"]
+        providers = raw_config.get_config_key("providers")
+        self.pro_subscene = providers["subscene"]
+        self.pro_opensubtitles_rss = providers["opensubtitles_rss"]
+        self.pro_opensubtitles_hash = providers["opensubtitles_hash"]
+        self.file_exist = True if __video__.name is not None else False
+        self.file_hash = file_manager.get_hash(__video__.path)
+        self.user_parameters = raw_config.UserParameters(
+            current_language=self.current_language,
+            hearing_impaired=self.hearing_impaired,
+            non_hearing_impaired=self.non_hearing_impaired,
+            percentage=self.percentage,
+            show_download_window=self.show_download_window,
+        )
+        self.opensubtitles_hash_results = None
+        self.opensubtitles_rss_results = None
+        self.subscene_results = None
+        self.opensubtitles_sorted_list = []
+        self.subscene_sorted_list = []
+        self.combined_sorted_list = []
+        self.opensubtitles_hash_downloads = 0
+        self.opensubtitles_rss_downloads = 0
+        self.subscene_downloads = 0
+        if self.file_exist:
+            self.file_hash = file_manager.get_hash(__video__.path)
+            self.parameters = string_parser.get_parameters(
+                __video__.name, self.file_hash, self.current_language, self.languages
+            )
+            log.parameters(self.parameters, self.user_parameters)
+
+
+class Steps(BaseInitializer):
+    def __init__(self):
+        self.start = time.perf_counter()
+        BaseInitializer.__init__(self)
+        ctypes.windll.kernel32.SetConsoleTitleW(f"SubSearch - {__version__}")
+        if current_user.got_key() is False:
+            raw_config.set_default_json()
+            raw_registry.add_context_menu()
+        if __video__.tmp_directory is not None:
+            if not os.path.exists(__video__.tmp_directory):
+                os.mkdir(__video__.tmp_directory)
+        if self.file_exist is False:
+            widget_menu.open_tab("search")
+            return None
+
+        if " " in __video__.name:
+            log.output("[Warning: Filename contains spaces]")
+
+    def _provider_opensubtitles(self):
+        if self.file_exist is False:
+            return None
+        if self.languages[self.current_language] == "N/A":
+            log.output("\n[Searching on opensubtitles]")
+            log.output(f"{self.current_language} not supported on opensubtitles\n")
+            return None
+
+        _opensubtitles = opensubtitles.OpenSubtitles(self.parameters, self.user_parameters)
+        if self.pro_opensubtitles_hash and self.file_hash is not None:
+            log.output("\n[Searching on opensubtitles - hash]")
+            self.opensubtitles_hash = _opensubtitles.parse_hash()
+        if self.pro_opensubtitles_rss:
+            log.output("\n[Searching on opensubtitles - rss]")
+            self.opensubtitles_rss = _opensubtitles.parse_rss()
+
+        self.opensubtitles_sorted_list = _opensubtitles.sorted_list()
+
+    def _provider_subscene(self):
+        if self.file_exist is False:
+            return None
+        if self.pro_subscene is False:
+            return None
+        log.output("\n[Searching on subscene - title]")
+        _subscene = subscene.Subscene(self.parameters, self.user_parameters)
+        self.subscene = _subscene.parse()
+        self.subscene_sorted_list = _subscene.sorted_list()
+
+    def _download_files(self):
+        if self.file_exist is False:
+            return None
+        if self.pro_opensubtitles_hash and self.opensubtitles_hash is not None:
+            log.output("\n[Downloading from opensubtitles - hash]")
+            for item in self.opensubtitles_hash:
+                self.opensubtitles_hash_downloads = file_manager.download_subtitle(item)
+                log.output("Done with tasks")
+                log.output("\n")
+        if self.pro_opensubtitles_rss and self.opensubtitles_rss is not None:
+            log.output("\n[Downloading from opensubtitles - rss]")
+            for item in self.opensubtitles_rss:
+                self.opensubtitles_rss_downloads = file_manager.download_subtitle(item)
+                log.output("Done with tasks")
+        if self.pro_subscene and self.subscene is not None:
+            log.output("\n[Downloading from subscene]")
+            for item in self.subscene:
+                self.subscene_downloads = file_manager.download_subtitle(item)
+                log.output("Done with tasks")
+
+    def _not_downloaded(self):
+        if self.file_exist is False:
+            return None
+        total_dls = self.opensubtitles_hash_downloads + self.opensubtitles_rss_downloads + self.subscene_downloads
+        if self.show_download_window and total_dls == 0:
+            self.combined_sorted_list = list(self.opensubtitles_sorted_list)
+            self.combined_sorted_list.extend(x for x in self.subscene_sorted_list if x not in self.combined_sorted_list)
+            self.combined_sorted_list.sort(key=lambda x: x[0], reverse=True)
+        if len(self.combined_sorted_list) > 0:
+            tmp_file = file_manager.write_not_downloaded_tmp(__video__.tmp_directory, self.combined_sorted_list)
+            widget_menu.open_tab("download")
+            file_manager.clean_up_files(__video__.tmp_directory, tmp_file)
+
+    def _clean_up(self):
+        if self.file_exist is False:
+            return None
+        log.output("\n[Proccessing downloads]")
+        file_manager.extract_files(__video__.tmp_directory, __video__.subs_directory, ".zip")
+        file_manager.clean_up_files(__video__.subs_directory, "nfo")
+        file_manager.del_directory(__video__.tmp_directory)
+        if self.rename_best_match:
+            file_manager.rename_best_match(f"{self.parameters.release}.srt", __video__.directory, ".srt")
+        log.output("Done with tasks")
+
+    def _pre_exit(self):
+        elapsed = time.perf_counter() - self.start
+        log.output(f"\nFinished in {elapsed} seconds")
+
+        if self.show_terminal and current_user.check_is_exe() is False:
+            try:
+                input("Ctrl + c or Enter to exit")
+            except KeyboardInterrupt:
+                pass

--- a/src/subsearch/data/__set_video__.py
+++ b/src/subsearch/data/__set_video__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from dataclasses import dataclass
 from itertools import product
@@ -10,6 +11,8 @@ class VideoFileData:
     ext: str | Any
     path: str | Any
     directory: str | Any
+    subs_directory: str | Any
+    tmp_directory: str | Any
 
 
 def get_video_file_data() -> VideoFileData:
@@ -41,12 +44,14 @@ def get_video_file_data() -> VideoFileData:
         if i[1].endswith(i[0]) and str(i[1])[i[1].rfind("\\") :].startswith("\\"):
             path = i[1]
             directory = path[: path.rfind("\\")]
+            tmp_directory = os.path.join(directory, ".subsearch")
+            subs_directory = os.path.join(directory, "subs")
             name = path[path.rfind("\\") + 1 :].rsplit(".", 1)[0]
             ext = i[0]
             file_exist = True
             break
 
     if file_exist:
-        return VideoFileData(name, ext, path, directory)
+        return VideoFileData(name, ext, path, directory, subs_directory, tmp_directory)
     else:
-        return VideoFileData(None, None, None, None)
+        return VideoFileData(name=None, ext=None, path=None, directory=None, subs_directory=None, tmp_directory=None)

--- a/src/subsearch/data/config.json
+++ b/src/subsearch/data/config.json
@@ -77,6 +77,7 @@
         "non_hearing_impaired": true
     },
     "percentage": 90,
+    "rename_best_match": true,
     "context_menu_icon": true,
     "show_download_window": true,
     "show_terminal": false,

--- a/src/subsearch/gui/tab_download.py
+++ b/src/subsearch/gui/tab_download.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tkinter as tk
 from tkinter import ttk
 
@@ -16,7 +17,7 @@ def read_tmp_file():
     if __video__.directory == None:
         return None
 
-    file = os.path.join(__video__.directory, "__subsearch__dl_data.tmp")
+    file = os.path.join(__video__.directory, "download_data.tmp")
     with open(file, "r") as f:
         return [line.strip() for line in f]
 
@@ -100,32 +101,22 @@ class DownloadList(tk.Frame):
     def download_button(self, event):
         self.sub_listbox.unbind("<<ListboxSelect>>")
         self.sub_listbox.bind("<ButtonRelease-1>", self.mouse_b1_release)
-        _i = str(self.sub_listbox.curselection())
-        _i = _i.replace("(", "")
-        _i = _i.replace(")", "")
-        items = _i.replace(",", "")
-        _error = False
+        selection = str(self.sub_listbox.curselection())
+        item_num = re.findall("(\d+)", selection)[0]
         for (number, _url), (_name) in zip(self.dicts_urls.items(), self.dicts_names.values()):
-            if number == int(items):
-                self.sub_listbox.delete(int(number))
-                self.sub_listbox.insert(int(number), f"»»» DOWNLOADING «««")
-                self.sub_listbox.itemconfig(int(number), {"fg": TKCOLOR.blue})
-                try:
-                    dl_url = self.subscene_scrape.download_url(_url)
-                    _name = _name.replace("/", "").replace("\\", "").split(": ")
-                    path = f"{__video__.directory}\\__subsearch__{_name[-1]}.zip"
-                    item = DownloadData(name=_name, file_path=path, url=dl_url, idx_num=1, idx_lenght=1)
-                    file_manager.download_subtitle(item)
-                    if _error is False:
-                        file_manager.extract_files(__video__.directory, ".zip")
-                        file_manager.clean_up(__video__.directory, ".zip")
-                        file_manager.clean_up(__video__.directory, ").nfo")
-                        self.sub_listbox.delete(int(number))
-                        self.sub_listbox.insert(int(number), f"✔ {_name[0]} {_name[1]}")
-                        self.sub_listbox.itemconfig(int(number), {"fg": TKCOLOR.green})
-                        _error = False
-                except OSError:
-                    _error = True
-                    self.sub_listbox.delete(int(number))
-                    self.sub_listbox.insert(int(number), f"⚠⚠⚠ Download failed ⚠⚠⚠")
-                    self.sub_listbox.itemconfig(int(number), {"fg": TKCOLOR.red})
+            if number != int(item_num):
+                continue
+            self.sub_listbox.delete(int(number))
+            self.sub_listbox.insert(int(number), f"»»» DOWNLOADING «««")
+            self.sub_listbox.itemconfig(int(number), {"fg": TKCOLOR.blue})
+            dl_url = self.subscene_scrape.download_url(_url)
+            _name = "".join(re.findall("[^\/\\\:\?\<\>\|\*]*", _name))
+            path = f"{__video__.directory}\\__subsearch__{_name[-1]}.zip"
+            item = DownloadData(name=_name, file_path=path, url=dl_url, idx_num=1, idx_lenght=1)
+            file_manager.download_subtitle(item)
+            file_manager.extract_files(__video__.directory, ".zip")
+            file_manager.clean_up_files(__video__.directory, ".zip")
+            file_manager.clean_up_files(__video__.directory, ").nfo")
+            self.sub_listbox.delete(int(number))
+            self.sub_listbox.insert(int(number), f"✔ {_name}")
+            self.sub_listbox.itemconfig(int(number), {"fg": TKCOLOR.green})

--- a/src/subsearch/gui/tab_search.py
+++ b/src/subsearch/gui/tab_search.py
@@ -186,15 +186,23 @@ class SearchThreshold(tk.Frame):
         self.pct = PCT
         label = tk.Label(self, text="Search threshold")
         label.configure(bg=TKCOLOR.dark_grey, fg=TKCOLOR.white_grey, font=TKFONT.cas8b)
+class RenameBestMatch(tk.Frame):
+    def __init__(self, parent):
+        tk.Frame.__init__(self, parent)
+        self.configure(bg=TKCOLOR.dark_grey)
+        self.string_var = tk.StringVar()
+        self.string_var.set(f"{RENAME_BEST_MATCH}")
+        label = tk.Label(self, text="Rename best match")
+        label.configure(bg=TKCOLOR.dark_grey, fg=TKCOLOR.white_grey, font=TKFONT.cas8b)
         label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
         self.clabel = tk.Label(self, textvariable=self.string_var)
         self.clabel.configure(bg=TKCOLOR.dark_grey, font=TKFONT.cas8b)
         self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)
-        tk_tools.ColorPicker(self.string_var, self.clabel, self.pct)
-        btn_add = tk.Button(
+        tk_tools.ColorPicker(self.string_var, self.clabel)
+        btn_true = tk.Button(
             self,
             font=TKFONT.cas8b,
-            text="+",
+            text="True",
             bd=0,
             bg=TKCOLOR.light_black,
             fg=TKCOLOR.white_grey,
@@ -202,11 +210,11 @@ class SearchThreshold(tk.Frame):
             height=2,
             width=18,
         )
-        btn_add.grid(row=0, column=3, pady=2)
-        btn_sub = tk.Button(
+        btn_true.grid(row=0, column=3, pady=2)
+        btn_false = tk.Button(
             self,
             font=TKFONT.cas8b,
-            text="-",
+            text="False",
             bd=0,
             bg=TKCOLOR.light_black,
             fg=TKCOLOR.white_grey,
@@ -214,38 +222,32 @@ class SearchThreshold(tk.Frame):
             height=2,
             width=18,
         )
-        btn_sub.grid(row=0, column=2, pady=2)
-        btn_add.bind("<Enter>", self.enter_button)
-        btn_add.bind("<Leave>", self.leave_button)
-        btn_sub.bind("<Enter>", self.enter_button)
-        btn_sub.bind("<Leave>", self.leave_button)
+        btn_false.grid(row=0, column=2, pady=2)
+        btn_true.bind("<Enter>", self.enter_button)
+        btn_true.bind("<Leave>", self.leave_button)
+        btn_false.bind("<Enter>", self.enter_button)
+        btn_false.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
 
     def enter_button(self, event):
         btn = event.widget
-        if btn["text"] == "+":
+        if btn["text"] == "True":
             btn.configure(bg=TKCOLOR.black, fg=TKCOLOR.green)
-            btn.bind("<ButtonRelease>", self.button_add_5)
-        if btn["text"] == "-":
+            btn.bind("<ButtonRelease>", self.button_set_true)
+        if btn["text"] == "False":
             btn.configure(bg=TKCOLOR.black, fg=TKCOLOR.red)
-            btn.bind("<ButtonRelease>", self.button_sub_5)
+            btn.bind("<ButtonRelease>", self.button_set_false)
 
     def leave_button(self, event):
         btn = event.widget
         btn.configure(bg=TKCOLOR.light_black, fg=TKCOLOR.white_grey)
+
+    def button_set_true(self, event):
+        self.string_var.set(f"True")
         tk_tools.ColorPicker(self.string_var, self.clabel)
+        raw_config.set_config_key_value("rename_best_match", True)
 
-    def button_add_5(self, event):
-        self.pct += 5 if self.pct < 100 else 0
-        self.string_var.set(f"{self.pct} %")
-
-        tk_tools.ColorPicker(self.string_var, self.clabel, self.pct)
-        update_svar = int(self.pct)
-        raw_config.set_config_key_value("percentage", update_svar)
-
-    def button_sub_5(self, event):
-        self.pct -= 5 if self.pct > 0 else 0
-        self.string_var.set(f"{self.pct} %")
-        tk_tools.ColorPicker(self.string_var, self.clabel, self.pct)
-        update_svar = int(self.pct)
-        raw_config.set_config_key_value("percentage", update_svar)
+    def button_set_false(self, event):
+        self.string_var.set(f"False")
+        tk_tools.ColorPicker(self.string_var, self.clabel)
+        raw_config.set_config_key_value("rename_best_match", False)

--- a/src/subsearch/gui/tab_search.py
+++ b/src/subsearch/gui/tab_search.py
@@ -1,4 +1,5 @@
 import tkinter as tk
+from tkinter import ttk
 
 from subsearch.data import __set_video__
 from subsearch.gui import tk_data, tk_tools
@@ -9,6 +10,7 @@ TKFONT = tk_data.Font()
 
 SUBTILE_TYPE = raw_config.get_config_key("subtitle_type")
 PCT = raw_config.get_config_key("percentage")
+RENAME_BEST_MATCH = raw_config.get_config_key("rename_best_match")
 PROVIDERS = raw_config.get_config_key("providers")
 
 
@@ -32,7 +34,7 @@ class Providers(tk.Frame):
             btn = tk.Button(
                 self,
                 font=TKFONT.cas8b,
-                text=key,
+                text=key.replace("_", " ").capitalize(),
                 bd=0,
                 bg=TKCOLOR.light_black,
                 fg=TKCOLOR.white_grey,
@@ -57,7 +59,7 @@ class Providers(tk.Frame):
 
     def leave_button(self, event):
         btn = event.widget
-        key = btn["text"]
+        key = btn["text"].replace(" ", "_").lower()
         if self.data["providers"][key] is True:
             btn.configure(bg=TKCOLOR.light_black, fg=TKCOLOR.green)
         if self.data["providers"][key] is False:
@@ -65,7 +67,7 @@ class Providers(tk.Frame):
 
     def press_button(self, event):
         btn = event.widget
-        key = btn["text"]
+        key = btn["text"].replace(" ", "_").lower()
         if self.data["providers"][key] is True:
             btn.configure(bg=TKCOLOR.light_black, fg=TKCOLOR.green)
             btn.bind("<ButtonRelease>", self.toggle_providers)
@@ -75,7 +77,7 @@ class Providers(tk.Frame):
 
     def toggle_providers(self, event):
         btn = event.widget
-        key = btn["text"]
+        key = btn["text"].replace(" ", "_").lower()
         if self.data["providers"][key] is True:
             self.data["providers"][key] = False
             btn.configure(fg=TKCOLOR.red)
@@ -112,7 +114,7 @@ class SubtitleType(tk.Frame):
             btn = tk.Button(
                 self,
                 font=TKFONT.cas8b,
-                text=key,
+                text=key.replace("_", " ").title(),
                 bd=0,
                 bg=TKCOLOR.light_black,
                 fg=TKCOLOR.white_grey,
@@ -137,7 +139,7 @@ class SubtitleType(tk.Frame):
 
     def leave_button(self, event):
         btn = event.widget
-        key = btn["text"]
+        key = btn["text"].replace(" ", "_").lower()
         if self.data["subtitle_type"][key] is True:
             btn.configure(bg=TKCOLOR.light_black, fg=TKCOLOR.green)
         if self.data["subtitle_type"][key] is False:
@@ -145,7 +147,7 @@ class SubtitleType(tk.Frame):
 
     def press_button(self, event):
         btn = event.widget
-        key = btn["text"]
+        key = btn["text"].replace(" ", "_").lower()
         if self.data["subtitle_type"][key] is True:
             btn.configure(bg=TKCOLOR.light_black, fg=TKCOLOR.green)
             btn.bind("<ButtonRelease>", self.toggle_types)
@@ -155,7 +157,7 @@ class SubtitleType(tk.Frame):
 
     def toggle_types(self, event):
         btn = event.widget
-        key = btn["text"]
+        key = btn["text"].replace(" ", "_").lower()
         if self.data["subtitle_type"][key] is True:
             self.data["subtitle_type"][key] = False
             btn.configure(fg=TKCOLOR.red)
@@ -181,11 +183,69 @@ class SearchThreshold(tk.Frame):
     def __init__(self, parent):
         tk.Frame.__init__(self, parent)
         self.configure(bg=TKCOLOR.dark_grey)
+        self.current_value = tk.IntVar()
+        self.current_value.set(PCT)
         self.string_var = tk.StringVar()
         self.string_var.set(f"{PCT} %")
-        self.pct = PCT
         label = tk.Label(self, text="Search threshold")
         label.configure(bg=TKCOLOR.dark_grey, fg=TKCOLOR.white_grey, font=TKFONT.cas8b)
+        label.grid(row=0, column=0, sticky="w", padx=0, pady=2)
+        self.clabel = tk.Label(self, textvariable=self.string_var)
+        self.clabel.configure(bg=TKCOLOR.dark_grey, font=TKFONT.cas8b)
+        self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)
+        tk_tools.ColorPicker(self.string_var, self.clabel, True)
+        x, y = tk_tools.calculate_btn_size(self, 36)
+        self.slider = ttk.Scale(
+            self, from_=0, to=100, orient="horizontal", variable=self.current_value, length=x
+        )  # vertical
+        self.slider.grid(column=2, row=0, sticky="we", padx=4)
+        self.slider.bind("<Enter>", self.enter_button)
+        self.slider.bind("<Leave>", self.leave_button)
+        tk_tools.set_default_grid_size(self)
+
+    def get_value(self):
+        return self.current_value.get()
+
+    def set_value(self, event):
+        self.string_var.set(f"{self.get_value()} %")
+
+    def enter_button(self, event):
+        btn = event.widget
+        if btn == self.slider:
+            self.slider.bind("<ButtonPress>", self.press_slider)
+            self.slider.bind("<Double-ButtonRelease-1>", self.dubble_press)
+
+    def leave_button(self, event):
+        btn = event.widget
+        if btn == self.slider:
+            self.slider.configure(command=self.set_value)
+
+    def dubble_press(self, event):
+        btn = event.widget
+        if btn == self.slider:
+            self.current_value.set(90)
+            self.string_var.set(f"{90} %")
+            self.slider.update()
+            self.update_config()
+
+    def press_slider(self, event):
+        btn = event.widget
+        if btn == self.slider:
+            self.slider.configure(command=self.set_value)
+            self.slider.bind("<ButtonRelease>", self.release_slider)
+
+    def release_slider(self, event):
+        btn = event.widget
+        if btn == self.slider:
+            self.slider.configure(command=self.set_value)
+            self.update_config()
+
+    def update_config(self):
+        update_svar = self.current_value.get()
+        raw_config.set_config_key_value("percentage", update_svar)
+        tk_tools.ColorPicker(self.string_var, self.clabel, True)
+
+
 class RenameBestMatch(tk.Frame):
     def __init__(self, parent):
         tk.Frame.__init__(self, parent)

--- a/src/subsearch/gui/tk_tools.py
+++ b/src/subsearch/gui/tk_tools.py
@@ -5,6 +5,7 @@ from tkinter import Label, StringVar
 
 from subsearch.data import __buttons__, __tabs__, __version__
 from subsearch.gui import tk_data
+from subsearch.utils import raw_config
 
 TKCOLOR = tk_data.Color()
 TKFONT = tk_data.Font()
@@ -34,10 +35,10 @@ def set_default_grid_size(_widget, _width=18):
     x, y = btn_size.winfo_reqwidth(), btn_size.winfo_reqheight()
     col_count, row_count = _widget.grid_size()
     for col in range(col_count):
-        _widget.grid_columnconfigure(col, minsize=x)
+            _widget.grid_columnconfigure(col, minsize=x)
 
     for row in range(row_count):
-        _widget.grid_rowconfigure(row, minsize=0)
+            _widget.grid_rowconfigure(row, minsize=0)
 
 
 class TitleBar(tk.Frame):
@@ -197,10 +198,10 @@ class WindowPosition(tk.Frame):
 
 
 class ColorPicker:
-    def __init__(self, string_var: StringVar, clabel: Label, pct: int = -1):
+    def __init__(self, string_var: StringVar, clabel: Label, is_pct: bool = False):
         self.string_var = string_var
         self.clabel = clabel
-        self.pct = pct
+        self.is_pct = is_pct
         self.pick()
 
     def pick(self):  # string boolean
@@ -212,15 +213,17 @@ class ColorPicker:
             self.clabel.configure(fg=TKCOLOR.blue)
         elif self.string_var.get().startswith("Only"):
             self.clabel.configure(fg=TKCOLOR.green)
-        # range
-        elif self.pct in range(75, 100):
-            self.clabel.configure(fg=TKCOLOR.green)
-        elif self.pct in range(50, 75):
-            self.clabel.configure(fg=TKCOLOR.green_brown)
-        elif self.pct in range(25, 50):
-            self.clabel.configure(fg=TKCOLOR.red_brown)
-        elif self.pct in range(0, 25):
-            self.clabel.configure(fg=TKCOLOR.red)
+
+        if self.is_pct:
+            _pct = raw_config.get_config_key("percentage")
+            if _pct in range(75, 101):
+                self.clabel.configure(fg=TKCOLOR.green)
+            elif _pct in range(50, 75):
+                self.clabel.configure(fg=TKCOLOR.green_brown)
+            elif _pct in range(25, 50):
+                self.clabel.configure(fg=TKCOLOR.red_brown)
+            elif _pct in range(0, 25):
+                self.clabel.configure(fg=TKCOLOR.red)
 
 
 class ToolTip(tk.Toplevel):

--- a/src/subsearch/gui/widget_menu.py
+++ b/src/subsearch/gui/widget_menu.py
@@ -209,6 +209,7 @@ class TabSearch(tk.Frame):
         tk.Frame(self, height=80, bg=TKCOLOR.dark_grey).pack(anchor="center", expand=True)
         tab_search.SubtitleType(self).pack(anchor="center")
         tab_search.SearchThreshold(self).pack(anchor="center")
+        tab_search.RenameBestMatch(self).pack(anchor="center")
 
 
 class TabSettings(tk.Frame):

--- a/src/subsearch/gui/widget_menu.py
+++ b/src/subsearch/gui/widget_menu.py
@@ -1,7 +1,6 @@
 import tkinter as tk
 
-import sv_ttk
-
+from subsearch.assets import sv_ttk
 from subsearch.gui import (
     base_root,
     tab_download,
@@ -231,12 +230,12 @@ class TabDownload(tk.Frame):
     def __init__(self, parent, con_x, con_y):
         tk.Frame.__init__(self, parent)
         self.configure(bg=TKCOLOR.dark_grey)
-        sv_ttk.set_theme("dark")
         tab_download.DownloadList(self, con_x, con_y).pack(anchor="center")
 
 
 def open_tab(active_tab: str):
     root = base_root.main()
+    sv_ttk.set_theme("grey")
     content = tk.Frame(root, bg=TKCOLOR.dark_grey, width=TKWINDOW.width - 4, height=TKWINDOW.height - 118)
     content.place(x=2, y=37)
     conx, cony = content.winfo_reqwidth(), content.winfo_reqheight()

--- a/src/subsearch/providers/generic.py
+++ b/src/subsearch/providers/generic.py
@@ -72,8 +72,8 @@ class BaseProvider:
         self.current_language = user_parameters.current_language
         self.hi_sub = user_parameters.hearing_impaired
         self.non_hi_sub = user_parameters.non_hearing_impaired
-        self.pct = user_parameters.pct
-        self.show_download_window = user_parameters.show_dl_window
+        self.pct = user_parameters.percentage
+        self.show_download_window = user_parameters.show_download_window
         # sorted_list
         self._sorted_list: list[DownloadData] = []
 

--- a/src/subsearch/providers/opensubtitles.py
+++ b/src/subsearch/providers/opensubtitles.py
@@ -30,7 +30,7 @@ class OpenSubtitles(BaseProvider):
         log.output(f"Preparing  hash {self.file_hash} for download")
         tbd_lenght = len(to_be_downloaded)
         for zip_idx, zip_url in enumerate(to_be_downloaded, start=1):
-            zip_fp = f"{__video__.directory}\\__subsearch__opensubtitles_{zip_idx}.zip"
+            zip_fp = f"{__video__.tmp_directory}\\opensubtitles_{zip_idx}.zip"
             data = DownloadData(file_path=zip_fp, url=zip_url, idx_num=zip_idx, idx_lenght=tbd_lenght)
             download_info.append(data)
         log.output(f"Done with tasks\n")
@@ -62,7 +62,7 @@ class OpenSubtitles(BaseProvider):
         download_info = []
         tbd_lenght = len(to_be_downloaded)
         for zip_idx, (zip_name, zip_url) in enumerate(to_be_downloaded.items(), start=1):
-            zip_fp = f"{__video__.directory}\\__subsearch__opensubtitles_{zip_idx}.zip"
+            zip_fp = f"{__video__.tmp_directory}\\opensubtitles_{zip_idx}.zip"
             data = DownloadData(name=zip_name, file_path=zip_fp, url=zip_url, idx_num=zip_idx, idx_lenght=tbd_lenght)
             download_info.append(data)
         log.output("Done with tasks\n")

--- a/src/subsearch/providers/subscene.py
+++ b/src/subsearch/providers/subscene.py
@@ -66,7 +66,7 @@ class Subscene(BaseProvider):
         tbd_lenght = len(to_be_downloaded)
         for zip_idx, (zip_name, _zip_url) in enumerate(to_be_downloaded.items(), start=1):
             zip_url = self.scrape.download_url(_zip_url)
-            zip_fp = f"{__video__.directory}\\__subsearch__subscene_{zip_idx}.zip"
+            zip_fp = f"{__video__.tmp_directory}\\subscene_{zip_idx}.zip"
             data = DownloadData(name=zip_name, file_path=zip_fp, url=zip_url, idx_num=zip_idx, idx_lenght=tbd_lenght)
             download_info.append(data)
         log.output("Done with tasks\n")

--- a/src/subsearch/utils/file_manager.py
+++ b/src/subsearch/utils/file_manager.py
@@ -21,14 +21,14 @@ def download_subtitle(data: DownloadData) -> int:
     return data.idx_num
 
 
-def extract_files(cwd: str, extension: str) -> None:
-    subs_folder = os.path.join(cwd, "subs")
+def extract_files(src: str, dst: str, extension: str) -> None:
+    subs_folder = os.path.join(dst, "subs")
     if not os.path.exists(subs_folder):
         os.mkdir(subs_folder)
-    for file in os.listdir(cwd):
-        if file.startswith("__subsearch__") and file.endswith(extension):
+    for file in os.listdir(src):
+        if file.endswith(extension):
             log.output(f"Extracting: {file} -> ..\\subs\\{file}")
-            filename = os.path.join(cwd, file)
+            filename = os.path.join(src, file)
             zip_ref = zipfile.ZipFile(filename)
             zip_ref.extractall(subs_folder)
             zip_ref.close()
@@ -55,16 +55,23 @@ def rename_best_match(release_name: str, cwd: str, extension: str) -> None:
         shutil.move(move_src, move_dst)
 
 
-def clean_up(cwd: str, extension: str) -> None:
+def clean_up_files(cwd: str, extension: str) -> None:
     for file in os.listdir(cwd):
-        if file.startswith("__subsearch__") and file.endswith(extension):
+        if file.endswith(extension):
             log.output(f"Removing: {file}")
             file_path = os.path.join(cwd, file)
             os.remove(file_path)
 
 
+def del_directory(directory: str) -> None:
+    for file in os.listdir(directory):
+        log.output(f"Removing: {file}")
+    log.output(f"Removing: {directory}")
+    shutil.rmtree(directory)
+
+
 def write_not_downloaded_tmp(dst: str, not_downloaded: list) -> str:
-    file_dst = f"{dst}\\__subsearch__dl_data.tmp"
+    file_dst = f"{dst}\\download_data.tmp"
     with open(file_dst, "w", encoding="utf8") as f:
         for i in range(len(not_downloaded)):
             name, _link = not_downloaded[i][1], not_downloaded[i][2]

--- a/src/subsearch/utils/log.py
+++ b/src/subsearch/utils/log.py
@@ -18,7 +18,7 @@ NOW = datetime.now()
 DATE = NOW.strftime("%y%m%d")
 
 logging.basicConfig(
-    filename=f"{CWD}\\__subsearch__.log",
+    filename=f"{CWD}\\subsearch.log",
     filemode="w",
     level=logging.DEBUG,
     format="%(asctime)s - %(message)s",
@@ -59,7 +59,7 @@ def parameters(param: FileSearchParameters, user_parameters: UserParameters) -> 
     output(f"Series:                     {param.series}")
     output(f"Release:                    {param.release}")
     output(f"Group:                      {param.group}")
-    output(f"Match threshold:            {user_parameters.pct}%")
+    output(f"Match threshold:            {user_parameters.percentage}%")
     output(f"File hash:                  {param.file_hash}")
     output(f"URL Subscene:               {param.url_subscene}")
     output(f"URL OpenSubtitles - rss:    {param.url_opensubtitles}")

--- a/src/subsearch/utils/raw_config.py
+++ b/src/subsearch/utils/raw_config.py
@@ -5,7 +5,6 @@ from typing import Any, NamedTuple, Union
 from subsearch.data import __data__
 
 
-# update config.json
 def set_config_key_value(key: str, value: Union[str, int, bool]) -> None:
     config_file = f"{__data__}\\config.json"
     with open(config_file, "r+", encoding="utf-8") as f:
@@ -32,7 +31,6 @@ def get_config() -> Any:
     return data
 
 
-# get said value(s) from config.json
 def get_config_key(key: str) -> Any:
     """
     Get values of keys in config.json
@@ -57,6 +55,7 @@ def get_config_key(key: str) -> Any:
         "languages": get_config()["languages"],
         "subtitle_type": get_config()["subtitle_type"],
         "percentage": get_config()["percentage"],
+        "rename_best_match": get_config()["rename_best_match"],
         "context_menu_icon": get_config()["context_menu_icon"],
         "show_download_window": get_config()["show_download_window"],
         "show_terminal": get_config()["show_terminal"],
@@ -72,6 +71,7 @@ def set_default_json() -> None:
     data["current_language"] = "English"
     data["subtitle_type"] = dict.fromkeys(data["subtitle_type"], True)
     data["percentage"] = 90
+    data["rename_best_match"] = True
     data["context_menu_icon"] = True
     data["show_download_window"] = True
     data["show_terminal"] = False
@@ -88,5 +88,5 @@ class UserParameters(NamedTuple):
     current_language: str
     hearing_impaired: bool
     non_hearing_impaired: bool
-    pct: int
-    show_dl_window: bool
+    percentage: int
+    show_download_window: bool

--- a/tests/test_utils_file_manager.py
+++ b/tests/test_utils_file_manager.py
@@ -36,9 +36,9 @@ def test_clean_up() -> None:
     """
     test the clean_up function in file_manager.py
     """
-    file_manager.clean_up(CWD, ".zip")
-    file_manager.clean_up(CWD, ".srt")
-    file_manager.clean_up(f"{CWD}\\subs", ".srt")
+    file_manager.clean_up_files(CWD, ".zip")
+    file_manager.clean_up_files(CWD, ".srt")
+    file_manager.clean_up_files(f"{CWD}\\subs", ".srt")
 
 
 def test_get_hash() -> None:

--- a/tests/test_utils_file_manager.py
+++ b/tests/test_utils_file_manager.py
@@ -22,7 +22,7 @@ def test_extract_zips() -> None:
     """
     test the extract_zips function in src/subsearch/utils/file_manager.py
     """
-    file_manager.extract_files(CWD, ".zip")
+    file_manager.extract_files(CWD, CWD, ".zip")
 
 
 def test_rename_best_match() -> None:
@@ -36,10 +36,10 @@ def test_clean_up() -> None:
     """
     test the clean_up function in file_manager.py
     """
-    file_manager.clean_up_files(CWD, ".zip")
-    file_manager.clean_up_files(CWD, ".srt")
-    file_manager.clean_up_files(f"{CWD}\\subs", ".srt")
-
+    subs = os.path.join(CWD, "subs")
+    file_manager.clean_up_files(subs, "srt")
+    file_manager.clean_up_files(CWD, "srt")
+    file_manager.clean_up_files(CWD, "__subsearch__test.subtitles.zip")
 
 def test_get_hash() -> None:
     """

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,5 @@ deps =
     -r{toxinidir}/docs/dev_requirements.txt
 commands =
     pytest --basetemp={envtmpdir}
-    isolated_build = true
+isolated_build = true
     


### PR DESCRIPTION
Added a config key `rename_best_match`, if True the best matching subtitle will be renamed to the release name so MPC and similar video players auto loads it. If false nothing happens.

__subsearch__.py contains all steps that the app does, moved out from __init__, so in the future these steps can be used around the code without circular imports.

New files, like downloaded .zip's are placed in  a .subsearch folder, instead of straight into where the video file is located

Slider instead of + and - buttons for search threshold value

New feats:
![Screenshot 2022-09-06 160531](https://user-images.githubusercontent.com/92130287/188656211-393bd726-72df-498d-af08-fa22edaea396.png)
