### PR TITLE
Tests fix FileNotFoundError:

### DIFF
--- a/tests/test_utils_file_manager.py
+++ b/tests/test_utils_file_manager.py
@@ -37,9 +37,12 @@ def test_clean_up() -> None:
     test the clean_up function in file_manager.py
     """
     subs = os.path.join(CWD, "subs")
+    if not os.path.exists(subs):
+        os.mkdir(subs)
     file_manager.clean_up_files(subs, "srt")
     file_manager.clean_up_files(CWD, "srt")
     file_manager.clean_up_files(CWD, "__subsearch__test.subtitles.zip")
+
 
 def test_get_hash() -> None:
     """


### PR DESCRIPTION
[WinError 3] The system cannot find the path specified: 'D:\\a\\subsearch\\subsearch\\tests\\test_files\\subs'