### PR TITLE
Fix Windows 8.1 registry key * not found

### DIFF
--- a/src/subsearch/utils/raw_registry.py
+++ b/src/subsearch/utils/raw_registry.py
@@ -8,6 +8,7 @@ from subsearch.data import __home__, __icon__
 from subsearch.utils import current_user
 
 COMPUTER_NAME = socket.gethostname()
+CLASSES_PATH = "Software\\Classes"
 ASTERISK_PATH = "Software\\Classes\\*"
 SHELL_PATH = "Software\\Classes\\*\\shell"
 SUBSEARCH_PATH = "Software\\Classes\\*\\shell\\0.subsearch"
@@ -16,7 +17,8 @@ COMMAND_PATH = "Software\\Classes\\*\\shell\\0.subsearch\\command"
 
 def write_keys() -> None:
     with winreg.ConnectRegistry(COMPUTER_NAME, winreg.HKEY_CURRENT_USER) as hkey:
-        # open key, with write permission
+        with winreg.OpenKey(hkey, CLASSES_PATH, 0, winreg.KEY_WRITE) as sk:
+            winreg.CreateKey(sk, "*")
         with winreg.OpenKey(hkey, ASTERISK_PATH, 0, winreg.KEY_WRITE) as sk:
             winreg.CreateKey(sk, "shell")
         with winreg.OpenKey(hkey, SHELL_PATH, 0, winreg.KEY_WRITE) as sk:


### PR DESCRIPTION
On win 8.1, there is no key `*` in HKEY_CURRENT_USER\Software\Classes\

The key gets created if there isn't one.