### PR TITLE
Python 3.11.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ old*
 scripts/git_branch.py
 src/subsearch/subsearch.log
 src/subsearch/test.py
+test_media/*

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Source is probably faster than the executable version, but the executable can be
 
 ### PyPi <a name = "pypi"></a>
 
-Download [Python](https://www.python.org/downloads/) 3.10
+Download [Python](https://www.python.org/downloads/) >= 3.10
 
 Install subsearch
 
@@ -88,7 +88,7 @@ See [code block](#code) for imports
 
 ### Source <a name = "src"></a>
 
-Download [Python](https://www.python.org/downloads/) 3.10
+Download [Python](https://www.python.org/downloads/) >= 3.10
 
 Download subsearch
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,3 @@ cloudscraper==1.2.65
 num2words==0.5.12
 packaging==21.3
 requests==2.28.1
-lxml==4.9.1
-cinemagoer==2022.2.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=63.2", "wheel"]
+requires = ["setuptools>=65.5", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ license_files = LICENSE
 platforms = win32
 classifiers =
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Operating System :: Microsoft :: Windows
     Topic :: Multimedia :: Video
     Topic :: Utilities
@@ -29,9 +30,7 @@ install_requires =
     cloudscraper>=1.2
     num2words>=0.5
     requests>=2.28
-    lxml>=4.9
     packaging>=21.3
-    cinemagoer>=2022.2.11
 python_requires = >=3.10
 zip_safe = no
 

--- a/src/subsearch/data/video_data.py
+++ b/src/subsearch/data/video_data.py
@@ -1,10 +1,11 @@
 import sys
 from itertools import product
 from pathlib import Path
+from typing import Optional, no_type_check
 
 from subsearch.data.data_fields import VideoFileData
 
-
+@no_type_check
 def get_video_file_data() -> VideoFileData:
 
     """

--- a/src/subsearch/gui/tab_download.py
+++ b/src/subsearch/gui/tab_download.py
@@ -54,7 +54,7 @@ class DownloadList(tk.Frame):
         self._releases = {}
         self._urls = {}
         log.output("")
-        log.output_header("[Processing files with GUI]")
+        log.output_header("Processing files with GUI")
         # fil list box with all available subtitles that were found and not downloaded
         for enu, data in enumerate(self.formatted_data):
             self.sub_listbox.insert(tk.END, f"{data.formatted_release}\n")

--- a/src/subsearch/gui/widget_menu.py
+++ b/src/subsearch/gui/widget_menu.py
@@ -197,7 +197,7 @@ def open_tab(active_tab: str, **kwargs):
     try:
         formatted_data: list[FormattedData] = kwargs["formatted_data"]
     except KeyError:
-        formatted_data = None
+        formatted_data = None # type: ignore
     root = base_root.main()
     gui.set_theme("dark")
     content = tk.Frame(root, bg=TkColor().dark_grey, width=TkWindowSize().width - 4, height=TkWindowSize().height - 118)

--- a/src/subsearch/providers/generic.py
+++ b/src/subsearch/providers/generic.py
@@ -96,7 +96,7 @@ class BaseProvider:
             raise CaptchaError("Captcha protection detected. Please try again later.")
 
 
-def get_lxml_doc(url: str, features: str = "lxml") -> BeautifulSoup:
+def get_lxml_doc(url: str, features: str = "html.parser") -> BeautifulSoup:
     source = SCRAPER.get(url)
     scontent = source.content
     doc = BeautifulSoup(scontent, features)

--- a/src/subsearch/providers/opensubtitles.py
+++ b/src/subsearch/providers/opensubtitles.py
@@ -77,7 +77,7 @@ class OpenSubtitlesScrape(OpenSubtitles):
 
     def get_subtitles(self, url: str):
         subtitles: dict[str, str] = {}
-        doc = generic.get_lxml_doc(url, "xml")
+        doc = generic.get_lxml_doc(url)
         items = doc.find_all("item")
         for item in items:
             dl_url = item.enclosure["url"]
@@ -88,7 +88,7 @@ class OpenSubtitlesScrape(OpenSubtitles):
 
     def with_hash(self, url: str, release: str) -> dict[str, str]:
         subtitles: dict[str, str] = {}
-        doc = generic.get_lxml_doc(url, "lxml")
+        doc = generic.get_lxml_doc(url)
         doc_results = doc.find("a", download="download", id="bt-dwl-bt")
         if doc_results is None:
             return subtitles

--- a/src/subsearch/providers/subscene.py
+++ b/src/subsearch/providers/subscene.py
@@ -120,7 +120,7 @@ class SubsceneScrape(Subscene):
 
     def get_download_url(self, url: str) -> str:
         source = SCRAPER.get(url).text
-        doc = BeautifulSoup(source, "lxml")
+        doc = BeautifulSoup(source, features="html.parser")
         button_url = [dl["href"] for dl in doc.find_all("a", href=True, id="downloadButton")]
         download_url = f"https://subscene.com/{button_url[0]}"
         return download_url

--- a/src/subsearch/utils/imdb.py
+++ b/src/subsearch/utils/imdb.py
@@ -1,0 +1,67 @@
+import re
+
+from subsearch.providers import generic
+
+
+class AdvTitleSearch:
+    def __init__(self, title: str, year: int) -> None:
+        self.title = title
+        self.year = year
+
+    def get_url(self):
+        imdb_domain = "https://www.imdb.com"
+        return f"{imdb_domain}/search/title/?{self.title_search}&{self.release_date_search}"
+
+    @property
+    def prior_year(self):
+        return f"{self.year-1}-01-01"
+
+    @property
+    def release_year(self):
+        return f"{self.year}-12-31"
+
+    @property
+    def release_title(self):
+        return self.title.replace(" ", "+")
+
+    @property
+    def title_search(self):
+        return f"title={self.release_title}"
+
+    @property
+    def release_date_search(self):
+        return f"release_date={self.prior_year},{self.release_year}"
+
+
+class FindImdbID(AdvTitleSearch):
+    def __init__(self, title: str, year: int):
+        self.title = title.lower()
+        self.year = year
+        self.id = None
+        adv_search = AdvTitleSearch(self.title, self.year)
+        url = adv_search.get_url()
+        doc = generic.get_lxml_doc(url)
+        items = doc.find_all("div", class_="lister-item-content")
+        for item in items:
+            self.data = item.find("h3", class_="lister-item-header")
+            if self.title != self.imdb_title:
+                continue
+            if self.year != self.imdb_year and (self.year - 1) != self.imdb_year:
+                continue
+            self.id = self.imdb_id
+            break
+
+    @property
+    def imdb_title(self) -> str:
+        title = self.data.contents[3].string
+        return title.lower()
+
+    @property
+    def imdb_year(self) -> int:
+        year = self.data.contents[5].string
+        return int(re.findall("[0-9]+", year)[0])
+
+    @property
+    def imdb_id(self) -> str:
+        href = self.data.contents[3].attrs["href"]
+        return re.findall("tt[0-9]+", href)[0]

--- a/src/subsearch/utils/log.py
+++ b/src/subsearch/utils/log.py
@@ -15,6 +15,10 @@ NOW = datetime.now()
 DATE = NOW.strftime("%y%m%d")
 LOG_TO_FILE = raw_config.get_config_key("log_to_file")
 
+release_data: ReleaseData
+user_data: UserData
+url_data: ProviderUrlData
+
 logger = logging.getLogger("subsearch")
 logger.setLevel(logging.DEBUG)
 

--- a/src/subsearch/utils/log.py
+++ b/src/subsearch/utils/log.py
@@ -151,7 +151,7 @@ def output_subtitle_result(to_be_downloaded: dict[str, str], to_be_sorted: list[
     output("")
 
 
-def output_title_data_result(found: bool, from_hash: str = False):
+def output_title_data_result(found: bool, from_hash: bool = False):
     def _not_found(media_type: str, from_hash: bool):
         if from_hash:
             output(f"Did not find a {media_type} matching hash: {release_data.file_hash}")

--- a/src/subsearch/utils/string_parser.py
+++ b/src/subsearch/utils/string_parser.py
@@ -1,10 +1,9 @@
 import re
-import time
 
-import imdb
 from num2words import num2words
 
 from subsearch.data.data_fields import ProviderUrlData, ReleaseData, UserData
+from subsearch.utils import imdb
 
 
 def find_year(string: str) -> int:
@@ -58,25 +57,6 @@ def find_group(string: str) -> str:
     return group
 
 
-def find_imdb_tt_id(title: str, year: int) -> str:
-    ia = imdb.Cinemagoer()
-    movies = ia.search_movie(title)
-    prev_year = year - 1
-    if not movies:
-        time.sleep(0.5)
-        movies = ia.search_movie(title)
-
-    for movie in movies:
-        movie_no_colon = movie.data["title"].replace(":", "").split("(")[0]
-        if movie_no_colon.lower() != title.lower():
-            continue
-        if movie.data["year"] != year and movie.data["year"] != prev_year:
-            continue
-        _movie_id: str = movie.movieID
-        tt_id = f"tt{_movie_id}"
-        return tt_id
-
-
 def find_title(filename: str, year: int, series: bool):
     if year != 0000:
         title = find_title_by_year(filename)
@@ -124,7 +104,7 @@ def get_provider_urls(file_hash: str, ucf: UserData, frd: ReleaseData) -> Provid
 
         url_subscene = f"{base_ss}/subtitles/searchbytitle?query={frd.title} ({frd.year})"
         url_opensubtitles = f"{base_os}/{sub_type_os}/searchonlymovies-on/moviename-{frd.title} ({frd.year})/rss_2_00"
-        tt_id = find_imdb_tt_id(frd.title, frd.year)
+        tt_id = imdb.FindImdbID(frd.title, frd.year).id
         if tt_id is None:
             url_yifysubtitles = "N/A"
         else:

--- a/tests/test_utils_string_parser.py
+++ b/tests/test_utils_string_parser.py
@@ -1,5 +1,6 @@
 from src.subsearch.core import BaseInitializer
-from src.subsearch.utils import log, raw_config, string_parser
+from src.subsearch.utils import raw_config, string_parser
+from src.subsearch.utils import imdb
 
 LANGUAGES = raw_config.get_config_key("languages")
 
@@ -117,5 +118,5 @@ def test_provider_urls_series():
 
 
 def test_imdb_tt_id():
-    tt_id = string_parser.find_imdb_tt_id("Arctic", 2019)
+    tt_id = imdb.FindImdbID("Arctic", 2019).id
     assert tt_id == "tt6820256"


### PR DESCRIPTION
Support for Python 3.11.0 and remove dependency cinemagoer.

Using html.parser instead of lxml until 4.9.2 is released with support for Python 3.11