### PR TITLE
 Fix subscene not returning a valid match

### DIFF
--- a/src/subsearch/utils/string_parser.py
+++ b/src/subsearch/utils/string_parser.py
@@ -102,7 +102,7 @@ def get_provider_urls(file_hash: str, ucf: UserData, frd: ReleaseData) -> Provid
 
     def _set_movie_url():
 
-        url_subscene = f"{base_ss}/subtitles/searchbytitle?query={frd.title} ({frd.year})"
+        url_subscene = f"{base_ss}/subtitles/searchbytitle?query={frd.title}"
         url_opensubtitles = f"{base_os}/{sub_type_os}/searchonlymovies-on/moviename-{frd.title} ({frd.year})/rss_2_00"
         tt_id = imdb.FindImdbID(frd.title, frd.year).id
         if tt_id is None:

--- a/tests/test_utils_string_parser.py
+++ b/tests/test_utils_string_parser.py
@@ -92,7 +92,7 @@ def test_provider_urls_movie():
     fsd = string_parser.get_file_search_data(filename, "000000000000000000")
     pud = string_parser.get_provider_urls("000000000000000000", base.user_data, fsd)
 
-    assert pud.subscene == "https://subscene.com/subtitles/searchbytitle?query=the%20foo%20bar%20(2021)"
+    assert pud.subscene == "https://subscene.com/subtitles/searchbytitle?query=the%20foo%20bar"
     assert (
         pud.opensubtitles
         == "https://www.opensubtitles.org/en/search/sublanguageid-eng/searchonlymovies-on/moviename-the%20foo%20bar%20(2021)/rss_2_00"


### PR DESCRIPTION
Removed year from `url_subscene`, if the release year in the filename does not match the year on subscene.

The movie will not show up in the results, not even as a 'close' match. The year can differ between the filename year and subscene, if the movie is released close to the end of a year and the premier of the movie is later for some countries.