### PR TITLE
Update workflow order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,16 +105,6 @@ jobs:
         with:
           ref: main
 
-      - name: Build changelog
-        id: github_release
-        uses: mikepenz/release-changelog-builder-action@v3
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          configuration: .github/configs/changelog_builder.json
-          ignorePreReleases: ${{ !contains(github.ref, '-') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -127,12 +117,25 @@ jobs:
           pip install -e .[dev,optional]
 
       - name: Build executable
+        id: build_executable
         run: |
           pyinstaller scripts/build.spec -y --clean --distpath ./subsearch-x64
+
       - name: Make archives
+        if: steps.build_executable.outcome
         run: |
           python scripts/make_archive.py
           mv ./subsearch-x64.zip ./subsearch-${{ github.ref_name }}-win-x64.zip
+
+      - name: Build changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v3
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          configuration: .github/configs/changelog_builder.json
+          ignorePreReleases: ${{ !contains(github.ref, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update changelog
         id: update_changelog
@@ -163,7 +166,7 @@ jobs:
   pypi-upload:
     if: ${{ !contains(github.ref, '-') }}
     name: Upload to PyPi
-    needs: versioning
+    needs: ["versioning", "build-and-publish"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Changed so I don't manually have to write the changelog if the executable fails to build.

Also the release doesn't get uploaded to PyPi