### PR TITLE
Introducing toggle buttons to replace redundant buttons

### DIFF
--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -169,50 +169,44 @@ class ShowDownloadWindow(tk.Frame):
         self.configure(bg=GUI_DATA.colors.dark_grey)
         self.string_var = tk.StringVar()
         self.string_var.set(f"{DLW_ON_FAIL}")
-        label = tk.Label(self, text="Download window")
-        label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
+        label = tk.Label(self, text="Show download window")
+        label.configure(DEFAULT_LABEL_CONFIG)
         label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
-        self.clabel = tk.Label(self, textvariable=self.string_var)
-        self.clabel.configure(bg=GUI_DATA.colors.dark_grey, font=GUI_DATA.fonts.cas8b)
-        self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
-        btn_true = ttk.Button(
+        btn_toggle = ttk.Button(
             self,
-            text="True",
+            textvariable=self.string_var,
             width=18,
+            style=f"{self.string_var.get()}.TButton",
         )
-        btn_true.grid(row=0, column=3, pady=2)
-        btn_false = ttk.Button(
-            self,
-            text="False",
-            width=18,
-        )
-        btn_false.grid(row=0, column=2, pady=2)
-        btn_true.bind("<Enter>", self.enter_button)
-        btn_true.bind("<Leave>", self.leave_button)
-        btn_false.bind("<Enter>", self.enter_button)
-        btn_false.bind("<Leave>", self.leave_button)
+        btn_toggle.grid(row=0, column=3, pady=2)
+        btn_toggle.bind("<Enter>", self.enter_button)
+        btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
+        
 
     def enter_button(self, event):
         btn = event.widget
         if btn["text"] == "True":
-            btn.bind("<ButtonRelease-1>", self.button_set_true)
-        if btn["text"] == "False":
             btn.bind("<ButtonRelease-1>", self.button_set_false)
+        if btn["text"] == "False":
+            btn.bind("<ButtonRelease-1>", self.button_set_true)
 
     def leave_button(self, event):
         btn = event.widget
 
     def button_set_true(self, event):
+        btn = event.widget
         self.string_var.set(f"True")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("manual_download_fail", True)
+        self.enter_button(event)
 
     def button_set_false(self, event):
+        btn = event.widget
         self.string_var.set(f"False")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("manual_download_fail", False)
+        self.enter_button(event)
 
 
 class ShowTerminalOnSearch(tk.Frame):

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -309,50 +309,43 @@ class UseThreading(tk.Frame):
         self.configure(bg=GUI_DATA.colors.dark_grey)
         self.string_var = tk.StringVar()
         self.string_var.set(f"{USE_THREADING}")
-        label = tk.Label(self, text="Use threading")
-        label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
-        label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
-        self.clabel = tk.Label(self, textvariable=self.string_var)
-        self.clabel.configure(bg=GUI_DATA.colors.dark_grey, font=GUI_DATA.fonts.cas8b)
-        self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
-        btn_true = ttk.Button(
+        label = tk.Label(self, text="Download window")
+        label.configure(DEFAULT_LABEL_CONFIG)
+        label.grid(DEFAULT_LABEL_GRID)
+        btn_toggle = ttk.Button(
             self,
-            text="True",
+            textvariable=self.string_var,
             width=18,
+            style=f"{self.string_var.get()}.TButton",
         )
-        btn_true.grid(row=0, column=3, pady=2)
-        btn_false = ttk.Button(
-            self,
-            text="False",
-            width=18,
-        )
-        btn_false.grid(row=0, column=2, pady=2)
-        btn_true.bind("<Enter>", self.enter_button)
-        btn_true.bind("<Leave>", self.leave_button)
-        btn_false.bind("<Enter>", self.enter_button)
-        btn_false.bind("<Leave>", self.leave_button)
+        btn_toggle.grid(row=0, column=3, pady=2)
+        btn_toggle.bind("<Enter>", self.enter_button)
+        btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
 
     def enter_button(self, event):
         btn = event.widget
         if btn["text"] == "True":
-            btn.bind("<ButtonRelease-1>", self.button_set_true)
-        if btn["text"] == "False":
             btn.bind("<ButtonRelease-1>", self.button_set_false)
+        if btn["text"] == "False":
+            btn.bind("<ButtonRelease-1>", self.button_set_true)
 
     def leave_button(self, event):
         btn = event.widget
 
     def button_set_true(self, event):
-        self.string_var.set(f"True")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn = event.widget
+        self.string_var.set(f"False")
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("use_threading", True)
+        self.enter_button(event)
 
     def button_set_false(self, event):
+        btn = event.widget
         self.string_var.set(f"False")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("use_threading", False)
+        self.enter_button(event)
 
 
 class CheckForUpdates(tk.Frame):

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -85,10 +85,10 @@ class ShowContextMenu(tk.Frame):
         btn_toggle = ttk.Button(
             self,
             textvariable=self.string_var,
-            width=18,
+            width=40,
             style=f"{self.string_var.get()}.TButton",
         )
-        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
+        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID, padx=8)
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
@@ -133,10 +133,10 @@ class ShowContextMenuIcon(tk.Frame):
         btn_toggle = ttk.Button(
             self,
             textvariable=self.string_var,
-            width=18,
+            width=40,
             style=f"{self.string_var.get()}.TButton",
         )
-        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
+        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID, padx=8)
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
@@ -180,10 +180,10 @@ class ShowDownloadWindow(tk.Frame):
         btn_toggle = ttk.Button(
             self,
             textvariable=self.string_var,
-            width=18,
+            width=40,
             style=f"{self.string_var.get()}.TButton",
         )
-        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
+        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID, padx=8)
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
@@ -226,10 +226,10 @@ class ShowTerminalOnSearch(tk.Frame):
             btn_toggle = ttk.Button(
                 self,
                 textvariable=self.string_var,
-                width=18,
+                width=40,
                 style=f"{self.string_var.get()}.TButton",
             )
-            btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
+            btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID, padx=8)
             btn_toggle.bind("<Enter>", self.enter_button)
             btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
@@ -273,10 +273,10 @@ class LogToFile(tk.Frame):
         btn_toggle = ttk.Button(
             self,
             textvariable=self.string_var,
-            width=18,
+            width=40,
             style=f"{self.string_var.get()}.TButton",
         )
-        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
+        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID, padx=8)
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
@@ -318,10 +318,10 @@ class UseThreading(tk.Frame):
         btn_toggle = ttk.Button(
             self,
             textvariable=self.string_var,
-            width=18,
+            width=40,
             style=f"{self.string_var.get()}.TButton",
         )
-        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
+        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID, padx=8)
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -214,54 +214,46 @@ class ShowTerminalOnSearch(tk.Frame):
         tk.Frame.__init__(self, parent)
         self.configure(bg=GUI_DATA.colors.dark_grey)
         self.string_var = tk.StringVar()
-        self.string_var.set(f"{SHOW_TERMINAL}")
-        label = tk.Label(self, text="Terminal on search")
-        label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
+        self.string_var.set(f"{DLW_ON_FAIL}")
+        label = tk.Label(self, text="Show download window")
+        label.configure(DEFAULT_LABEL_CONFIG)
         label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
-        self.clabel = tk.Label(self, textvariable=self.string_var)
-        self.clabel.configure(bg=GUI_DATA.colors.dark_grey, font=GUI_DATA.fonts.cas8b)
-        self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
         if file_manager.running_from_exe() is False:
-            btn_true = ttk.Button(
+            btn_toggle = ttk.Button(
                 self,
-                text="True",
+                textvariable=self.string_var,
                 width=18,
+                style=f"{self.string_var.get()}.TButton",
             )
-            btn_true.grid(row=0, column=3, pady=2)
-            btn_false = ttk.Button(
-                self,
-                text="False",
-                width=18,
-            )
-            btn_false.grid(row=0, column=2, pady=2)
-        btn_true.bind("<Enter>", self.enter_button)
-        btn_true.bind("<Leave>", self.leave_button)
-        btn_false.bind("<Enter>", self.enter_button)
-        btn_false.bind("<Leave>", self.leave_button)
-        tk_tools.set_default_grid_size(self)
+            btn_toggle.grid(row=0, column=3, pady=2)
+            btn_toggle.bind("<Enter>", self.enter_button)
+            btn_toggle.bind("<Leave>", self.leave_button)
 
     def enter_button(self, event):
         btn = event.widget
         if btn["text"] == "True":
-            btn.bind("<ButtonRelease-1>", self.button_set_true)
-        if btn["text"] == "False":
             btn.bind("<ButtonRelease-1>", self.button_set_false)
+        if btn["text"] == "False":
+            btn.bind("<ButtonRelease-1>", self.button_set_true)
 
     def leave_button(self, event):
         btn = event.widget
 
     def button_set_true(self, event):
+        btn = event.widget
         self.string_var.set(f"True")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("show_terminal", True)
         raw_registry.write_valuex("command")
+        self.enter_button(event)
 
     def button_set_false(self, event):
+        btn = event.widget
         self.string_var.set(f"False")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("show_terminal", False)
         raw_registry.write_valuex("command")
+        self.enter_button(event)
 
 
 class LogToFile(tk.Frame):

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -88,7 +88,7 @@ class ShowContextMenu(tk.Frame):
             width=18,
             style=f"{self.string_var.get()}.TButton",
         )
-        btn_toggle.grid(row=0, column=3, pady=2)
+        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
@@ -358,7 +358,7 @@ class CheckForUpdates(tk.Frame):
         self.string_var = tk.StringVar()
         self.string_var.set(f"")
         label = tk.Label(self, text=f"Version {__version__}")
-        label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
+        label.configure(DEFAULT_LABEL_CONFIG)
         label.grid(DEFAULT_LABEL_GRID)
         self.clabel = tk.Label(self, textvariable=self.string_var)
         self.clabel.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.yellow, font=GUI_DATA.fonts.cas8b)

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -82,54 +82,43 @@ class ShowContextMenu(tk.Frame):
         label = tk.Label(self, text="Context menu")
         label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
         label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
-        self.clabel = tk.Label(self, textvariable=self.string_var)
-        self.clabel.configure(bg=GUI_DATA.colors.dark_grey, font=GUI_DATA.fonts.cas8b)
-        self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
-        btn_true = ttk.Button(
+        self.btn_toggle = ttk.Button(
             self,
-            text="True",
+            textvariable=self.string_var,
             width=18,
+            style=f"{self.string_var.get()}.TButton",
         )
-        btn_true.grid(row=0, column=3, pady=2)
-        btn_false = ttk.Button(
-            self,
-            text="False",
-            width=18,
-        )
-        btn_false.grid(row=0, column=2, pady=2)
-        btn_true.bind("<Enter>", self.enter_button)
-        btn_true.bind("<Leave>", self.leave_button)
-        btn_false.bind("<Enter>", self.enter_button)
-        btn_false.bind("<Leave>", self.leave_button)
+        self.btn_toggle.grid(row=0, column=3, pady=2)
+        self.btn_toggle.bind("<Enter>", self.enter_button)
+        self.btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
 
     def enter_button(self, event):
         btn = event.widget
         if btn["text"] == "True":
-            btn.bind("<ButtonRelease-1>", self.button_set_true)
-        if btn["text"] == "False":
             btn.bind("<ButtonRelease-1>", self.button_set_false)
+        if btn["text"] == "False":
+            btn.bind("<ButtonRelease-1>", self.button_set_true)
 
     def leave_button(self, event):
         btn = event.widget
 
     def button_set_true(self, event):
+        btn = event.widget
         self.string_var.set(f"True")
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("context_menu", True)
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
-        from subsearch.utils import raw_registry
-
         raw_registry.add_context_menu()
         raw_registry.write_all_valuex()
+        self.enter_button(event)
 
     def button_set_false(self, event):
+        btn = event.widget
         self.string_var.set(f"False")
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("context_menu", False)
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
-        from subsearch.utils import raw_registry
-
         raw_registry.remove_context_menu()
+        self.enter_button(event)
 
 
 class ShowContextMenuIcon(tk.Frame):

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -15,6 +15,8 @@ MANUAL_MODE = raw_config.get_config_key("manual_download_mode")
 FILE_EXTENSIONS = raw_config.get_config_key("file_extensions")
 USE_THREADING = raw_config.get_config_key("use_threading")
 DEFAULT_LABEL_CONFIG = dict(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
+DEFAULT_LABEL_GRID = dict(row=0, column=0, sticky="w", padx=2, pady=2)
+
 
 class FileExtensions(tk.Frame):
     def __init__(self, parent):
@@ -23,8 +25,8 @@ class FileExtensions(tk.Frame):
         self.data = raw_config.get_config()
         number_of_buttons = len(FILE_EXTENSIONS.items())
         label = tk.Label(self, text="File extensions")
-        label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
-        label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
+        label.configure(DEFAULT_LABEL_CONFIG)
+        label.grid(DEFAULT_LABEL_GRID)
         self.rownum = 0
         self.colnum = 0
         self.checkbox_value = {}
@@ -78,7 +80,7 @@ class ShowContextMenu(tk.Frame):
         self.string_var.set(f"{CONTEXT_MENU}")
         label = tk.Label(self, text="Context menu")
         label.configure(DEFAULT_LABEL_CONFIG)
-        label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
+        label.grid(DEFAULT_LABEL_GRID)
         btn_toggle = ttk.Button(
             self,
             textvariable=self.string_var,
@@ -126,7 +128,7 @@ class ShowContextMenuIcon(tk.Frame):
         self.string_var.set(f"{CONTEXT_MENU_ICON}")
         label = tk.Label(self, text="Context menu icon")
         label.configure(DEFAULT_LABEL_CONFIG)
-        label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
+        label.grid(DEFAULT_LABEL_GRID)
         btn_toggle = ttk.Button(
             self,
             textvariable=self.string_var,
@@ -171,9 +173,9 @@ class ShowDownloadWindow(tk.Frame):
         self.configure(bg=GUI_DATA.colors.dark_grey)
         self.string_var = tk.StringVar()
         self.string_var.set(f"{DLW_ON_FAIL}")
-        label = tk.Label(self, text="Show download window")
+        label = tk.Label(self, text="Download window")
         label.configure(DEFAULT_LABEL_CONFIG)
-        label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
+        label.grid(DEFAULT_LABEL_GRID)
         btn_toggle = ttk.Button(
             self,
             textvariable=self.string_var,
@@ -184,7 +186,6 @@ class ShowDownloadWindow(tk.Frame):
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
-        
 
     def enter_button(self, event):
         btn = event.widget
@@ -216,10 +217,10 @@ class ShowTerminalOnSearch(tk.Frame):
         tk.Frame.__init__(self, parent)
         self.configure(bg=GUI_DATA.colors.dark_grey)
         self.string_var = tk.StringVar()
-        self.string_var.set(f"{DLW_ON_FAIL}")
-        label = tk.Label(self, text="Show download window")
+        self.string_var.set(f"{SHOW_TERMINAL}")
+        label = tk.Label(self, text="Terminal on search")
         label.configure(DEFAULT_LABEL_CONFIG)
-        label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
+        label.grid(DEFAULT_LABEL_GRID)
         if file_manager.running_from_exe() is False:
             btn_toggle = ttk.Button(
                 self,
@@ -230,6 +231,7 @@ class ShowTerminalOnSearch(tk.Frame):
             btn_toggle.grid(row=0, column=3, pady=2)
             btn_toggle.bind("<Enter>", self.enter_button)
             btn_toggle.bind("<Leave>", self.leave_button)
+        tk_tools.set_default_grid_size(self)
 
     def enter_button(self, event):
         btn = event.widget
@@ -356,7 +358,7 @@ class CheckForUpdates(tk.Frame):
         self.string_var.set(f"")
         label = tk.Label(self, text=f"Version {__version__}")
         label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
-        label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
+        label.grid(DEFAULT_LABEL_GRID)
         self.clabel = tk.Label(self, textvariable=self.string_var)
         self.clabel.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.yellow, font=GUI_DATA.fonts.cas8b)
         self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -8,12 +8,13 @@ from subsearch.utils import file_manager, raw_config, raw_registry, updates
 
 SHOW_TERMINAL = raw_config.get_config_key("show_terminal")
 LOG_TO_FILE = raw_config.get_config_key("log_to_file")
+CONTEXT_MENU = raw_config.get_config_key("context_menu")
 CONTEXT_MENU_ICON = raw_config.get_config_key("context_menu_icon")
 DLW_ON_FAIL = raw_config.get_config_key("manual_download_fail")
 MANUAL_MODE = raw_config.get_config_key("manual_download_mode")
 FILE_EXTENSIONS = raw_config.get_config_key("file_extensions")
 USE_THREADING = raw_config.get_config_key("use_threading")
-
+DEFAULT_LABEL_CONFIG = dict(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
 
 class FileExtensions(tk.Frame):
     def __init__(self, parent):
@@ -74,23 +75,19 @@ class ShowContextMenu(tk.Frame):
         tk.Frame.__init__(self, parent)
         self.configure(bg=GUI_DATA.colors.dark_grey)
         self.string_var = tk.StringVar()
-        context_menu_value = raw_config.get_config_key("context_menu")
-        if context_menu_value == 1:
-            self.string_var.set("True")
-        else:
-            self.string_var.set("False")
+        self.string_var.set(f"{CONTEXT_MENU}")
         label = tk.Label(self, text="Context menu")
-        label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
+        label.configure(DEFAULT_LABEL_CONFIG)
         label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
-        self.btn_toggle = ttk.Button(
+        btn_toggle = ttk.Button(
             self,
             textvariable=self.string_var,
             width=18,
             style=f"{self.string_var.get()}.TButton",
         )
-        self.btn_toggle.grid(row=0, column=3, pady=2)
-        self.btn_toggle.bind("<Enter>", self.enter_button)
-        self.btn_toggle.bind("<Leave>", self.leave_button)
+        btn_toggle.grid(row=0, column=3, pady=2)
+        btn_toggle.bind("<Enter>", self.enter_button)
+        btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
 
     def enter_button(self, event):
@@ -127,9 +124,11 @@ class ShowContextMenuIcon(tk.Frame):
         self.configure(bg=GUI_DATA.colors.dark_grey)
         self.string_var = tk.StringVar()
         self.string_var.set(f"{CONTEXT_MENU_ICON}")
-        label = tk.Label(self, text="Context menu icon")
-        label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
-        label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
+        label_context_menu_icon = tk.Label(self, text="Context menu icon")
+        label_context_menu_icon.configure(
+            bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b
+        )
+        label_context_menu_icon.grid(row=0, column=0, sticky="w", padx=2, pady=2)
         self.clabel = tk.Label(self, textvariable=self.string_var)
         self.clabel.configure(bg=GUI_DATA.colors.dark_grey, font=GUI_DATA.fonts.cas8b)
         self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -264,50 +264,43 @@ class LogToFile(tk.Frame):
         self.configure(bg=GUI_DATA.colors.dark_grey)
         self.string_var = tk.StringVar()
         self.string_var.set(f"{LOG_TO_FILE}")
-        label = tk.Label(self, text="Create subsearch.log")
-        label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
-        label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
-        self.clabel = tk.Label(self, textvariable=self.string_var)
-        self.clabel.configure(bg=GUI_DATA.colors.dark_grey, font=GUI_DATA.fonts.cas8b)
-        self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
-        btn_true = ttk.Button(
+        label = tk.Label(self, text="Download window")
+        label.configure(DEFAULT_LABEL_CONFIG)
+        label.grid(DEFAULT_LABEL_GRID)
+        btn_toggle = ttk.Button(
             self,
-            text="True",
+            textvariable=self.string_var,
             width=18,
+            style=f"{self.string_var.get()}.TButton",
         )
-        btn_true.grid(row=0, column=3, pady=2)
-        btn_false = ttk.Button(
-            self,
-            text="False",
-            width=18,
-        )
-        btn_false.grid(row=0, column=2, pady=2)
-        btn_true.bind("<Enter>", self.enter_button)
-        btn_true.bind("<Leave>", self.leave_button)
-        btn_false.bind("<Enter>", self.enter_button)
-        btn_false.bind("<Leave>", self.leave_button)
+        btn_toggle.grid(row=0, column=3, pady=2)
+        btn_toggle.bind("<Enter>", self.enter_button)
+        btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
 
     def enter_button(self, event):
         btn = event.widget
         if btn["text"] == "True":
-            btn.bind("<ButtonRelease-1>", self.button_set_true)
-        if btn["text"] == "False":
             btn.bind("<ButtonRelease-1>", self.button_set_false)
+        if btn["text"] == "False":
+            btn.bind("<ButtonRelease-1>", self.button_set_true)
 
     def leave_button(self, event):
         btn = event.widget
 
     def button_set_true(self, event):
-        self.string_var.set(f"True")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn = event.widget
+        self.string_var.set(f"False")
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("log_to_file", True)
+        self.enter_button(event)
 
     def button_set_false(self, event):
+        btn = event.widget
         self.string_var.set(f"False")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("log_to_file", False)
+        self.enter_button(event)
 
 
 class UseThreading(tk.Frame):

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -124,57 +124,42 @@ class ShowContextMenuIcon(tk.Frame):
         self.configure(bg=GUI_DATA.colors.dark_grey)
         self.string_var = tk.StringVar()
         self.string_var.set(f"{CONTEXT_MENU_ICON}")
-        label_context_menu_icon = tk.Label(self, text="Context menu icon")
-        label_context_menu_icon.configure(
-            bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b
-        )
-        label_context_menu_icon.grid(row=0, column=0, sticky="w", padx=2, pady=2)
-        self.clabel = tk.Label(self, textvariable=self.string_var)
-        self.clabel.configure(bg=GUI_DATA.colors.dark_grey, font=GUI_DATA.fonts.cas8b)
-        self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
-        btn_true = ttk.Button(
+        label = tk.Label(self, text="Context menu icon")
+        label.configure(DEFAULT_LABEL_CONFIG)
+        label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
+        btn_toggle = ttk.Button(
             self,
-            text="True",
+            textvariable=self.string_var,
             width=18,
+            style=f"{self.string_var.get()}.TButton",
         )
-        btn_true.grid(row=0, column=3, pady=2)
-        btn_false = ttk.Button(
-            self,
-            text="False",
-            width=18,
-        )
-        btn_false.grid(row=0, column=2, pady=2)
-        btn_true.bind("<Enter>", self.enter_button)
-        btn_true.bind("<Leave>", self.leave_button)
-        btn_false.bind("<Enter>", self.enter_button)
-        btn_false.bind("<Leave>", self.leave_button)
+        btn_toggle.grid(row=0, column=3, pady=2)
+        btn_toggle.bind("<Enter>", self.enter_button)
+        btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
 
     def enter_button(self, event):
         btn = event.widget
         if btn["text"] == "True":
-            btn.bind("<ButtonRelease-1>", self.button_set_true)
-        if btn["text"] == "False":
             btn.bind("<ButtonRelease-1>", self.button_set_false)
+        if btn["text"] == "False":
+            btn.bind("<ButtonRelease-1>", self.button_set_true)
 
     def leave_button(self, event):
         btn = event.widget
 
     def button_set_true(self, event):
+        btn = event.widget
         self.string_var.set(f"True")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("context_menu_icon", True)
-        from subsearch.utils import raw_registry
-
         raw_registry.write_valuex("icon")
 
     def button_set_false(self, event):
+        btn = event.widget
         self.string_var.set(f"False")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("context_menu_icon", False)
-        from subsearch.utils import raw_registry
-
         raw_registry.write_valuex("icon")
 
 

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -154,6 +154,7 @@ class ShowContextMenuIcon(tk.Frame):
         btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("context_menu_icon", True)
         raw_registry.write_valuex("icon")
+        self.enter_button(event)
 
     def button_set_false(self, event):
         btn = event.widget
@@ -161,6 +162,7 @@ class ShowContextMenuIcon(tk.Frame):
         btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("context_menu_icon", False)
         raw_registry.write_valuex("icon")
+        self.enter_button(event)
 
 
 class ShowDownloadWindow(tk.Frame):

--- a/src/subsearch/gui/tab_application_settings.py
+++ b/src/subsearch/gui/tab_application_settings.py
@@ -16,6 +16,7 @@ FILE_EXTENSIONS = raw_config.get_config_key("file_extensions")
 USE_THREADING = raw_config.get_config_key("use_threading")
 DEFAULT_LABEL_CONFIG = dict(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
 DEFAULT_LABEL_GRID = dict(row=0, column=0, sticky="w", padx=2, pady=2)
+DEFAULT_BTN_TOGGLE_GRID = dict(row=0, column=2, pady=2)
 
 
 class FileExtensions(tk.Frame):
@@ -135,7 +136,7 @@ class ShowContextMenuIcon(tk.Frame):
             width=18,
             style=f"{self.string_var.get()}.TButton",
         )
-        btn_toggle.grid(row=0, column=3, pady=2)
+        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
@@ -182,7 +183,7 @@ class ShowDownloadWindow(tk.Frame):
             width=18,
             style=f"{self.string_var.get()}.TButton",
         )
-        btn_toggle.grid(row=0, column=3, pady=2)
+        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
@@ -228,7 +229,7 @@ class ShowTerminalOnSearch(tk.Frame):
                 width=18,
                 style=f"{self.string_var.get()}.TButton",
             )
-            btn_toggle.grid(row=0, column=3, pady=2)
+            btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
             btn_toggle.bind("<Enter>", self.enter_button)
             btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
@@ -275,7 +276,7 @@ class LogToFile(tk.Frame):
             width=18,
             style=f"{self.string_var.get()}.TButton",
         )
-        btn_toggle.grid(row=0, column=3, pady=2)
+        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
@@ -320,7 +321,7 @@ class UseThreading(tk.Frame):
             width=18,
             style=f"{self.string_var.get()}.TButton",
         )
-        btn_toggle.grid(row=0, column=3, pady=2)
+        btn_toggle.grid(DEFAULT_BTN_TOGGLE_GRID)
         btn_toggle.bind("<Enter>", self.enter_button)
         btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)

--- a/src/subsearch/gui/tab_search_settings.py
+++ b/src/subsearch/gui/tab_search_settings.py
@@ -224,45 +224,37 @@ class RenameBestMatch(tk.Frame):
         label = tk.Label(self, text="Rename best match")
         label.configure(bg=GUI_DATA.colors.dark_grey, fg=GUI_DATA.colors.white_grey, font=GUI_DATA.fonts.cas8b)
         label.grid(row=0, column=0, sticky="w", padx=2, pady=2)
-        self.clabel = tk.Label(self, textvariable=self.string_var)
-        self.clabel.configure(bg=GUI_DATA.colors.dark_grey, font=GUI_DATA.fonts.cas8b)
-        self.clabel.grid(row=0, column=1, sticky="nsew", padx=2, pady=2)
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
-        btn_true = ttk.Button(
+        btn_toggle = ttk.Button(
             self,
-            text="True",
-            width=18,
+            textvariable=self.string_var,
+            width=40,
+            style=f"{self.string_var.get()}.TButton",
         )
-        btn_true.grid(row=0, column=3, pady=2)
-        btn_false = ttk.Button(
-            self,
-            text="False",
-            width=18,
-        )
-        btn_false.grid(row=0, column=2, pady=2)
-
-        btn_true.bind("<Enter>", self.enter_button)
-        btn_true.bind("<Leave>", self.leave_button)
-        btn_false.bind("<Enter>", self.enter_button)
-        btn_false.bind("<Leave>", self.leave_button)
+        btn_toggle.grid(row=0, column=2, pady=4, padx=8)
+        btn_toggle.bind("<Enter>", self.enter_button)
+        btn_toggle.bind("<Leave>", self.leave_button)
         tk_tools.set_default_grid_size(self)
 
     def enter_button(self, event):
         btn = event.widget
         if btn["text"] == "True":
-            btn.bind("<ButtonRelease>", self.button_set_true)
+            btn.bind("<ButtonRelease-1>", self.button_set_false)
         if btn["text"] == "False":
-            btn.bind("<ButtonRelease>", self.button_set_false)
+            btn.bind("<ButtonRelease-1>", self.button_set_true)
 
     def leave_button(self, event):
         btn = event.widget
 
     def button_set_true(self, event):
-        self.string_var.set(f"True")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn = event.widget
+        self.string_var.set(f"False")
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("rename_best_match", True)
+        self.enter_button(event)
 
     def button_set_false(self, event):
+        btn = event.widget
         self.string_var.set(f"False")
-        tk_tools.VarColorPicker(self.string_var, self.clabel)
+        btn["style"] = f"{self.string_var.get()}.TButton"
         raw_config.set_config_key_value("rename_best_match", False)
+        self.enter_button(event)

--- a/src/subsearch/gui/tk_tools.py
+++ b/src/subsearch/gui/tk_tools.py
@@ -54,6 +54,13 @@ def update_asset(cls, img, x, y):
     cls.photoimage = img
 
 
+def set_custom_btn_styles():
+    custom_style = ttk.Style()
+    # configure the style option for a specific widget (in this case, a ttk.Button)
+    custom_style.configure("True.TButton", foreground=GUI_DATA.colors.green)
+    custom_style.configure("False.TButton", foreground=GUI_DATA.colors.red)
+
+
 class WindowPosition(tk.Frame):
     def __init__(self, parent):
         tk.Frame.__init__(self, parent)

--- a/src/subsearch/gui/tk_tools.py
+++ b/src/subsearch/gui/tk_tools.py
@@ -27,7 +27,7 @@ def calculate_checkbtn_size(cls, _width=16):
 
 def set_default_grid_size(cls, _width=18):
     btn_size = tk.Button(cls, width=_width, height=2)
-    x, y = btn_size.winfo_reqwidth(), btn_size.winfo_reqheight()
+    x, _y = btn_size.winfo_reqwidth(), btn_size.winfo_reqheight()
     col_count, row_count = cls.grid_size()
     for col in range(col_count):
         cls.grid_columnconfigure(col, minsize=x)

--- a/src/subsearch/gui/widget_menu.py
+++ b/src/subsearch/gui/widget_menu.py
@@ -1,4 +1,5 @@
 import tkinter as tk
+from tkinter import ttk
 from typing import Any
 
 from subsearch.data import GUI_DATA, __paths__
@@ -128,6 +129,7 @@ def open_tab(active_tab: str, **kwargs) -> None:
         formatted_data = None  # type: ignore
     root = main()
     set_theme("dark")
+    tk_tools.set_custom_btn_styles()
     tabs = {
         "language": TabLanguage(root),
         "search": TabSearch(root),


### PR DESCRIPTION
Refactored all classes that has buttons false/true, into toggle buttons.


For example:

Refactors RenameBestMatch  class by replacing two buttons with a single toggle button. The toggle button uses the text variable to display the current state of the context menu setting and changes its style based on the state. The enter_button method is updated to bind the button to the appropriate function depending on its current state. The button_set_true and button_set_false methods are also updated to change the style of the button when the state is changed.

Also lined up widgets, to fit with the untouched widgets .

Result:

![Screenshot 2023-03-01 225419](https://user-images.githubusercontent.com/92130287/222273708-16b46d50-a1bf-4b32-bc62-794415678416.png)
