### PR TITLE
Delete ignorePreReleases from workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           configuration: .github/configs/changelog_builder.json
-          ignorePreReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Set the `ignorePreReleases` input to `false` in the `mikepenz/release-changelog-builder-action` action, so that the changelog includes changes from all tags (including pre-releases) when generating the changelog.

Previously, the `ignorePreReleases` input was set to a conditional expression that excluded pre-release tags based on certain criteria. This caused previous changelogs to be missing changes from pre-release tags that did not meet the specified criteria.