### PR TITLE
Updated variable names and imports in subsearch codebase and tests

### DIFF
--- a/src/subsearch/core.py
+++ b/src/subsearch/core.py
@@ -1,7 +1,7 @@
 import ctypes
 import time
 
-from subsearch.data import __version__, __video__
+from subsearch.data import __version__, video_data
 from subsearch.data.data_objects import DownloadMetaData, FormattedMetadata
 from subsearch.gui import tab_manager
 from subsearch.providers import opensubtitles, subscene, yifysubtitles
@@ -11,9 +11,9 @@ from subsearch.utils import file_manager, io_json, io_winreg, log, string_parser
 class Initializer:
     def __init__(self) -> None:
         self.app_config = io_json.get_app_config()
-        if __video__ is not None:
+        if video_data is not None:
             self.file_exist = True
-            self.file_hash = file_manager.get_hash(__video__.file_path)
+            self.file_hash = file_manager.get_hash(video_data.file_path)
         else:
             self.file_exist = False
             self.file_hash = "000000000000000000"
@@ -31,7 +31,7 @@ class Initializer:
         self.ran_download_tab = False
         self.skip_step = SkipStep(self)
         if self.file_exist:
-            self.release_data = string_parser.get_release_metadata(__video__.filename, self.file_hash)
+            self.release_data = string_parser.get_release_metadata(video_data.filename, self.file_hash)
             create_provider_urls = string_parser.CreateProviderUrls(
                 self.file_hash, self.app_config, self.release_data, self.language_data
             )
@@ -71,7 +71,7 @@ class AppSteps(Initializer):
             tab_manager.open_tab("search")
             return None
 
-        if " " in __video__.filename:
+        if " " in video_data.filename:
             log.warning_spaces_in_filename()
         log.output_header("Search started")
 
@@ -130,7 +130,7 @@ class AppSteps(Initializer):
         if self.skip_step.extract_zip():
             return None
         log.output_header("Extracting downloads")
-        file_manager.extract_files(__video__.tmp_directory, __video__.subs_directory, ".zip")
+        file_manager.extract_files(video_data.tmp_directory, video_data.subs_directory, ".zip")
         log.output_done_with_tasks(end_new_line=True)
 
     def _clean_up(self) -> None:
@@ -138,12 +138,12 @@ class AppSteps(Initializer):
             return None
         if self.app_config.rename_best_match:
             log.output_header("Renaming best match")
-            file_manager.rename_best_match(f"{self.release_data.release}.srt", __video__.directory_path, ".srt")
+            file_manager.rename_best_match(f"{self.release_data.release}.srt", video_data.directory_path, ".srt")
             log.output_done_with_tasks(end_new_line=True)
 
         log.output_header("Cleaning up")
-        file_manager.clean_up_files(__video__.subs_directory, "nfo")
-        file_manager.del_directory(__video__.tmp_directory)
+        file_manager.clean_up_files(video_data.subs_directory, "nfo")
+        file_manager.del_directory(video_data.tmp_directory)
         log.output_done_with_tasks(end_new_line=True)
 
     def _pre_exit(self) -> None:

--- a/src/subsearch/data/__init__.py
+++ b/src/subsearch/data/__init__.py
@@ -1,3 +1,6 @@
 from .data_objects import GUI_DATA
-from .set_data import __paths__, __video__
+from .set_data import app_paths, video_data
 from .version import __version__
+
+
+__all__ = [GUI_DATA, app_paths, video_data, __version__]

--- a/src/subsearch/data/data_objects.py
+++ b/src/subsearch/data/data_objects.py
@@ -133,8 +133,8 @@ class ProviderUrls:
 
     Attributes:
         subscene(str): URL of the subscene provider.
-        opensubtitles(str): URL of the opensubtitle provider.
-        opensubtitles_hash(str): Hash URL of the opensubtitle provider.
+        opensubtitles(str): URL of the opensubtitles provider.
+        opensubtitles_hash(str): Hash URL of the opensubtitles provider.
         yifysubtitles(str): URL of the yifysubtitles provider.
     """
 

--- a/src/subsearch/data/set_data.py
+++ b/src/subsearch/data/set_data.py
@@ -75,5 +75,5 @@ def video_file() -> FileData:
         return FileData(name, ext, file_path, directory, subs_directory, tmp_directory)
 
 
-__video__ = video_file()
-__paths__ = paths()
+video_data = video_file()
+app_paths = paths()

--- a/src/subsearch/gui/tab_manager.py
+++ b/src/subsearch/gui/tab_manager.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 from typing import Any
 
-from subsearch.data import GUI_DATA, __paths__
+from subsearch.data import GUI_DATA, app_paths
 from subsearch.data.data_objects import FormattedMetadata
 from subsearch.gui import set_theme, tkinter_utils
 from subsearch.gui.tabs import dowload_tab, language_tab, search_tab, settings_tab
@@ -186,7 +186,7 @@ def initalize_root():
         io_winreg.add_context_menu()
     root = tk.Tk(className=f"Subsearch")
     root.configure(background=GUI_DATA.colors.dark_grey)
-    root.iconbitmap(__paths__.icon)
+    root.iconbitmap(app_paths.icon)
     root.geometry(tkinter_utils.WindowPosition.set(root))
     root.resizable(False, False)
     return root

--- a/src/subsearch/gui/tabs/dowload_tab.py
+++ b/src/subsearch/gui/tabs/dowload_tab.py
@@ -2,7 +2,7 @@ import re
 import tkinter as tk
 from tkinter import ttk
 
-from subsearch.data import GUI_DATA, __video__
+from subsearch.data import GUI_DATA, video_data
 from subsearch.data.data_objects import DownloadMetaData, FormattedMetadata
 from subsearch.providers import subscene
 from subsearch.utils import file_manager, log
@@ -86,7 +86,7 @@ class DownloadList(tk.Frame):
                 download_url = self.subscene_scrape.get_download_url(_url)
             else:
                 download_url = _url
-            path = f"{__video__.tmp_directory}\\__{_provider}__{item_num}.zip"
+            path = f"{video_data.tmp_directory}\\__{_provider}__{item_num}.zip"
             enum = DownloadMetaData(
                 provider=f"Downloading from {_provider}",
                 name=_release,
@@ -96,8 +96,8 @@ class DownloadList(tk.Frame):
                 idx_lenght=1,
             )  # type: ignore
             file_manager.download_subtitle(enum)  # type: ignore
-            file_manager.extract_files(__video__.tmp_directory, __video__.subs_directory, ".zip")
-            file_manager.clean_up_files(__video__.tmp_directory, "zip")
+            file_manager.extract_files(video_data.tmp_directory, video_data.subs_directory, ".zip")
+            file_manager.clean_up_files(video_data.tmp_directory, "zip")
             break
         self.sub_listbox.delete(int(item_num))
         self.sub_listbox.insert(int(item_num), f"✔ {_release}")

--- a/src/subsearch/gui/tkinter_utils.py
+++ b/src/subsearch/gui/tkinter_utils.py
@@ -2,7 +2,7 @@ import tkinter as tk
 from pathlib import Path
 from tkinter import Label, StringVar, ttk
 
-from subsearch.data import GUI_DATA, __paths__, __version__, __video__
+from subsearch.data import GUI_DATA, __version__, app_paths, video_data
 from subsearch.utils import file_manager, io_json, io_winreg
 
 GWL_EXSTYLE = -20
@@ -27,7 +27,7 @@ def get_tab_png(tab: str) -> Path:
     Raises:
         None.
     """
-    return Path(__paths__.tabs) / tab
+    return Path(app_paths.tabs) / tab
 
 
 def calculate_btn_size(cls, width_=18, height_=2) -> tuple[int, int]:

--- a/src/subsearch/providers/opensubtitles.py
+++ b/src/subsearch/providers/opensubtitles.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any
 
-from subsearch.data import __video__
+from subsearch.data import video_data
 from subsearch.data.data_objects import (
     AppConfig,
     DownloadMetaData,
@@ -71,7 +71,7 @@ class OpenSubtitles(ProviderParameters, OpenSubtitlesScraper):
         log.output_match("opensubtitles", 100, self.release)
 
         # pack download data
-        download_info = generic.pack_download_data("opensubtitles", __video__.tmp_directory, to_be_downloaded)
+        download_info = generic.pack_download_data("opensubtitles", video_data.tmp_directory, to_be_downloaded)
         return download_info
 
     def parse_site_results(self) -> list | list[DownloadMetaData]:
@@ -104,7 +104,7 @@ class OpenSubtitles(ProviderParameters, OpenSubtitlesScraper):
             return []
 
         # pack download data
-        download_info = generic.pack_download_data("opensubtitles", __video__.tmp_directory, to_be_downloaded)
+        download_info = generic.pack_download_data("opensubtitles", video_data.tmp_directory, to_be_downloaded)
         return download_info
 
     def _sorted_list(self) -> list[FormattedMetadata]:

--- a/src/subsearch/providers/subscene.py
+++ b/src/subsearch/providers/subscene.py
@@ -1,6 +1,6 @@
 from selectolax.parser import Node
 
-from subsearch.data import __video__
+from subsearch.data import video_data
 from subsearch.data.data_objects import (
     AppConfig,
     DownloadMetaData,
@@ -109,7 +109,7 @@ class Subscene(ProviderParameters, SubsceneScraper):
             return []
 
         # pack download data
-        download_info = generic.pack_download_data("subscene", __video__.tmp_directory, to_be_downloaded)
+        download_info = generic.pack_download_data("subscene", video_data.tmp_directory, to_be_downloaded)
         return download_info
 
     def _sorted_list(self) -> list[FormattedMetadata]:

--- a/src/subsearch/providers/yifysubtitles.py
+++ b/src/subsearch/providers/yifysubtitles.py
@@ -1,6 +1,6 @@
 from selectolax.parser import Node
 
-from subsearch.data import __video__
+from subsearch.data import video_data
 from subsearch.data.data_objects import (
     AppConfig,
     DownloadMetaData,
@@ -80,7 +80,7 @@ class YifiSubtitles(ProviderParameters, YifySubtitlesScraper):
             return []
 
         # pack download data
-        download_info = generic.pack_download_data("yifysubtitles", __video__.tmp_directory, to_be_downloaded)
+        download_info = generic.pack_download_data("yifysubtitles", video_data.tmp_directory, to_be_downloaded)
         return download_info
 
     def _sorted_list(self) -> list[FormattedMetadata]:

--- a/src/subsearch/utils/file_manager.py
+++ b/src/subsearch/utils/file_manager.py
@@ -5,7 +5,7 @@ import sys
 import zipfile
 from pathlib import Path
 
-from subsearch.data import __video__
+from subsearch.data import video_data
 from subsearch.data.data_objects import DownloadMetaData
 from subsearch.providers.generic import get_cloudscraper
 from subsearch.utils import log, string_parser
@@ -78,10 +78,10 @@ def rename_best_match(release_name: str, cwd: Path, extension: str) -> None:
     Returns:
         None.
     """
-    if __video__ is None:
+    if video_data is None:
         return None
     higest_value = (0, "")
-    for file in os.listdir(__video__.subs_directory):
+    for file in os.listdir(video_data.subs_directory):
         if file.endswith(extension):
             value = string_parser.calculate_match(file, release_name)
             if value >= higest_value[0]:
@@ -89,8 +89,8 @@ def rename_best_match(release_name: str, cwd: Path, extension: str) -> None:
 
     file_to_rename = higest_value[1]
     if file_to_rename.endswith(extension):
-        old_name_src = Path(__video__.subs_directory) / file_to_rename
-        new_name_dst = Path(__video__.subs_directory) / release_name
+        old_name_src = Path(video_data.subs_directory) / file_to_rename
+        new_name_dst = Path(video_data.subs_directory) / release_name
         log.output(f"Renaming: {file_to_rename } -> {release_name}")
         os.rename(old_name_src, new_name_dst)
         move_src = new_name_dst
@@ -139,12 +139,12 @@ def make_necessary_directories():
     Make necessary directories using video object info.
     """
 
-    if __video__ is None:
+    if video_data is None:
         return None
-    if not Path(__video__.tmp_directory).exists():
-        Path.mkdir(__video__.tmp_directory)
-    if not Path(__video__.subs_directory).exists():
-        Path.mkdir(__video__.subs_directory)
+    if not Path(video_data.tmp_directory).exists():
+        Path.mkdir(video_data.tmp_directory)
+    if not Path(video_data.subs_directory).exists():
+        Path.mkdir(video_data.subs_directory)
 
 
 def get_hash(file_path: Path | None) -> str:

--- a/src/subsearch/utils/io_json.py
+++ b/src/subsearch/utils/io_json.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Any, Union
 
-from subsearch.data import __paths__
+from subsearch.data import app_paths
 from subsearch.data.data_objects import AppConfig, LanguageData
 
 
@@ -17,7 +17,7 @@ def set_config_key_value(key: str, value: Union[str, int, bool]) -> None:
     Returns:
         None
     """
-    config_file = Path(__paths__.data) / "application_config.json"
+    config_file = Path(app_paths.data) / "application_config.json"
 
     with open(config_file, "r+", encoding="utf-8") as f:
         data = json.load(f)
@@ -38,7 +38,7 @@ def set_config(data: dict[str, Union[str, int, bool]]) -> None:
     Returns:
         None
     """
-    config_file = Path(__paths__.data) / "application_config.json"
+    config_file = Path(app_paths.data) / "application_config.json"
     with open(config_file, "w") as f:
         f.seek(0)
         json.dump(data, f, indent=4)
@@ -55,7 +55,7 @@ def get_config() -> Any:
     Returns:
         Any: The contents of config.json file.
     """
-    config_file = Path(__paths__.data) / "application_config.json"
+    config_file = Path(app_paths.data) / "application_config.json"
     with open(config_file, encoding="utf-8") as file:
         data = json.load(file)
     return data
@@ -100,7 +100,7 @@ def set_default_json() -> None:
     data["log_to_file"] = False
     data["file_extensions"] = dict.fromkeys(data["file_extensions"], True)
     data["providers"] = dict.fromkeys(data["providers"], True)
-    config_file = Path(__paths__.data) / "application_config.json"
+    config_file = Path(app_paths.data) / "application_config.json"
     with open(config_file, "r+", encoding="utf-8") as file:
         file.seek(0)
         json.dump(data, file, indent=4)
@@ -114,7 +114,7 @@ def get_app_config() -> AppConfig:
     Returns:
         AppConfig: instance containing the current application configuration settings.
     """
-    config_file = Path(__paths__.data) / "application_config.json"
+    config_file = Path(app_paths.data) / "application_config.json"
     with open(config_file, encoding="utf-8") as file:
         data = json.load(file)
     user_data = AppConfig(
@@ -136,7 +136,7 @@ def get_language_data(language: str = get_config_key("current_language")) -> Lan
     Returns:
         A LanguageData object containing the data associated with the specified language.
     """
-    config_file = Path(__paths__.data) / "languages.json"
+    config_file = Path(app_paths.data) / "languages.json"
     with open(config_file, encoding="utf-8") as file:
         data = json.load(file)
     language_data = LanguageData(**data[language])
@@ -144,7 +144,7 @@ def get_language_data(language: str = get_config_key("current_language")) -> Lan
 
 
 def get_available_languages() -> dict:
-    config_file = Path(__paths__.data) / "languages.json"
+    config_file = Path(app_paths.data) / "languages.json"
     with open(config_file, encoding="utf-8") as file:
         data = json.load(file)
         return data

--- a/src/subsearch/utils/io_winreg.py
+++ b/src/subsearch/utils/io_winreg.py
@@ -3,7 +3,7 @@ import sys
 import winreg
 from pathlib import Path
 
-from subsearch.data import __paths__
+from subsearch.data import app_paths
 from subsearch.utils import file_manager
 
 COMPUTER_NAME = socket.gethostname()
@@ -108,7 +108,7 @@ def get_command_value() -> str:
         # import_sys = "import sys; media_file_path = sys.argv[-1];"
         set_title = "import ctypes; ctypes.windll.kernel32.SetConsoleTitleW('subsearch');"
         # gets the path of the root directory of subsearch
-        set_wd = f"import os; os.chdir(r'{__paths__.home}');"
+        set_wd = f"import os; os.chdir(r'{app_paths.home}');"
         import_main = "import subsearch; subsearch.main()"
         if show_terminal is True:
             value = f'{python_path}\python.exe -c "{set_title} {set_wd} {import_main}" "%1"'
@@ -130,7 +130,7 @@ def get_icon_value() -> str:
 
     show_icon: str = io_json.get_config_key("context_menu_icon")
     if show_icon:
-        return str(__paths__.icon)
+        return str(app_paths.icon)
     else:
         return ""
 

--- a/src/subsearch/utils/log.py
+++ b/src/subsearch/utils/log.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from threading import Lock
 
-from subsearch.data import __version__, __video__
+from subsearch.data import __version__, video_data
 from subsearch.data.data_objects import (
     AppConfig,
     FormattedMetadata,
@@ -26,10 +26,10 @@ language_data: LanguageData
 logger = logging.getLogger("subsearch")
 logger.setLevel(logging.DEBUG)
 
-if __video__ is not None and LOG_TO_FILE:
+if video_data is not None and LOG_TO_FILE:
     warnings.filterwarnings("ignore", lineno=545)
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s", datefmt="%d-%b-%y %H:%M:%S")
-    file_handler = logging.FileHandler(Path(__video__.directory_path) / "subsearch.log", "w")
+    file_handler = logging.FileHandler(Path(video_data.directory_path) / "subsearch.log", "w")
     file_handler.setLevel(logging.INFO)
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
@@ -37,7 +37,7 @@ if __video__ is not None and LOG_TO_FILE:
 
 def output(msg: str, terminal: bool = True, to_log: bool = True, level: str = "info"):
     def _to_log(msg: str, level: str) -> None:
-        if __video__ is None or LOG_TO_FILE is False:
+        if video_data is None or LOG_TO_FILE is False:
             return None
         if to_log is False:
             return None
@@ -66,7 +66,7 @@ def output(msg: str, terminal: bool = True, to_log: bool = True, level: str = "i
 
 
 def warning_spaces_in_filename():
-    name_unresolved = f"{__video__.filename}{__video__.file_extension}"
+    name_unresolved = f"{video_data.filename}{video_data.file_extension}"
     output(f"File: '{name_unresolved}' contains spaces", level="warning")
     output(f"Results may vary, use punctuation marks for a more accurate result", level="info")
     output("")
@@ -102,8 +102,8 @@ def output_parameters() -> None:
     output(f"Use site yifysubtitles:           {app_config.providers['subscene_site']}")
     output("")
     output_header(f"File data")
-    output(f"Filename:                         {__video__.filename}")
-    output(f"Directory:                        {__video__.directory_path}")
+    output(f"Filename:                         {video_data.filename}")
+    output(f"Directory:                        {video_data.directory_path}")
     output("")
     output_header(f"Release data")
     output(f"Title:                            {release_metadata.title}")

--- a/tests/test_data_set_data_.py
+++ b/tests/test_data_set_data_.py
@@ -1,13 +1,17 @@
 from pathlib import Path
 
-from src.subsearch.data import __paths__
+from src.subsearch.data import app_paths
 
 
 def test_paths() -> None:
-    assert __paths__.home == Path(Path.cwd()) / "src" / "subsearch"
-    assert __paths__.data == Path(Path.cwd()) / "src" / "subsearch" / "data"
-    assert __paths__.gui == Path(Path.cwd()) / "src" / "subsearch" / "gui"
-    assert __paths__.providers == Path(Path.cwd()) / "src" / "subsearch" / "providers"
-    assert __paths__.utils == Path(Path.cwd()) / "src" / "subsearch" / "utils"
-    assert __paths__.icon == Path(Path.cwd()) / "src" / "subsearch" / "gui" / "assets" / "icon" / "subsearch.ico"
-    assert __paths__.tabs == Path(Path.cwd()) / "src" / "subsearch" / "gui" / "assets" / "tabs"
+    """Test function for app_paths module.
+
+    This function tests whether various path constants defined in app_paths module are correctly defined.
+    """
+    assert app_paths.home == Path(Path.cwd()) / "src" / "subsearch"
+    assert app_paths.data == Path(Path.cwd()) / "src" / "subsearch" / "data"
+    assert app_paths.gui == Path(Path.cwd()) / "src" / "subsearch" / "gui"
+    assert app_paths.providers == Path(Path.cwd()) / "src" / "subsearch" / "providers"
+    assert app_paths.utils == Path(Path.cwd()) / "src" / "subsearch" / "utils"
+    assert app_paths.icon == Path(Path.cwd()) / "src" / "subsearch" / "gui" / "assets" / "icon" / "subsearch.ico"
+    assert app_paths.tabs == Path(Path.cwd()) / "src" / "subsearch" / "gui" / "assets" / "tabs"

--- a/tests/test_data_set_video.py
+++ b/tests/test_data_set_video.py
@@ -1,5 +1,5 @@
-from src.subsearch.data import __video__
+from src.subsearch.data import video_data
 
 
 def test_paths() -> None:
-    assert __video__ is None
+    assert video_data is None


### PR DESCRIPTION
- Rename global variables `__video__` and `__paths__` to `video_data` and `app_paths` respectively in multiple files
- Change import statements to use `video_data` and `app_paths`
- Refactor and simplify methods to remove duplication in some files
- Update the assertion to test for the correct variable name in `test_data_set_video.py`.
- Improve clarity and rewrite test paths in `test_data_set_data_.py`.