### PR TITLE
Implement a foreign language-only filter for Subscene

### DIFF
--- a/src/subsearch/core.py
+++ b/src/subsearch/core.py
@@ -87,6 +87,7 @@ class AppSteps(Initializer):
         if self.file_exist is False:
             tab_manager.open_tab("search")
             return None
+        self.foreign_only = io_json.get_json_key("foreign_only")
 
         if " " in video_data.filename:
             log.warning_spaces_in_filename()
@@ -187,6 +188,8 @@ class SkipStep:
     def opensubtitles(self) -> bool:
         if self.cls.file_exist is False:
             return True
+        if self.cls.foreign_only:
+            return True
         if io_json.check_language_compatibility("opensubtitles") is False:
             return True
         if (
@@ -207,6 +210,8 @@ class SkipStep:
 
     def yifysubtitles(self) -> bool:
         if self.cls.file_exist is False:
+            return True
+        if self.cls.foreign_only:
             return True
         if io_json.check_language_compatibility("yifysubtitles") is False:
             return True

--- a/src/subsearch/data/data_objects.py
+++ b/src/subsearch/data/data_objects.py
@@ -8,6 +8,7 @@ class LanguageData:
     alpha_1: str
     alpha_2b: str
     incompatibility: list[str]
+    subscene_id: int
 
 
 @dataclass(order=True)
@@ -91,6 +92,7 @@ class AppConfig:
 
     current_language: str
     subtitle_type: dict[str, bool]
+    foreign_only: bool
     percentage_threshold: int
     rename_best_match: bool
     context_menu: bool
@@ -105,6 +107,15 @@ class AppConfig:
     providers: dict[str, bool]
     hearing_impaired: bool
     non_hearing_impaired: bool
+
+
+@dataclass(order=True)
+class SubsceneCookie:
+    dark_theme: bool
+    sort_subtitle_by_date: str
+    language_filter: int
+    hearing_impaired: bool
+    foreigen_only: bool
 
 
 @dataclass(frozen=True, order=True)

--- a/src/subsearch/data/languages.json
+++ b/src/subsearch/data/languages.json
@@ -1,422 +1,514 @@
 {
-	"albanian": {
-		"name": "Albanian",
-		"alpha_1": "sq",
-		"alpha_2b": "alb",
-		"incompatibility": []
-	},
-	"arabic": {
-		"name": "Arabic",
-		"alpha_1": "ar",
-		"alpha_2b": "ara",
-		"incompatibility": []
-	},
-	"armenian": {
-		"name": "Armenian",
-		"alpha_1": "hy",
-		"alpha_2b": "arm",
-		"incompatibility": []
-	},
-	"azerbaijani": {
-		"name": "Azerbaijani",
-		"alpha_1": "az",
-		"alpha_2b": "aze",
-		"incompatibility": []
-	},
-	"basque": {
-		"name": "Basque",
-		"alpha_1": "eu",
-		"alpha_2b": "baq",
-		"incompatibility": []
-	},
-	"belarusian": {
-		"name": "Belarusian",
-		"alpha_1": "be",
-		"alpha_2b": "bel",
-		"incompatibility": []
-	},
-	"bosnian": {
-		"name": "Bosnian",
-		"alpha_1": "bs",
-		"alpha_2b": "bos",
-		"incompatibility": []
-	},
-	"brazillian_portuguese": {
-		"name": "Brazillian-Portuguese",
-		"alpha_1": "pt",
-		"alpha_2b": "pob",
-		"incompatibility": []
-	},
-	"bulgarian": {
-		"name": "Bulgarian",
-		"alpha_1": "bg",
-		"alpha_2b": "bul",
-		"incompatibility": []
-	},
-	"bulgarian_english": {
-		"name": "Bulgarian-English",
-		"alpha_1": null,
-		"alpha_2b": null,
-		"incompatibility": ["opensubtitles"]
-	},
-	"burmese": {
-		"name": "Burmese",
-		"alpha_1": "my",
-		"alpha_2b": "bur",
-		"incompatibility": []
-	},
-	"cambodian_khmer": {
-		"name": "Cambodian-Khmer",
-		"alpha_1": "km",
-		"alpha_2b": "khm",
-		"incompatibility": []
-	},
-	"catalan": {
-		"name": "Catalan",
-		"alpha_1": "ca",
-		"alpha_2b": "cat",
-		"incompatibility": []
-	},
-	"chinese_bg_code": {
-		"name": "Chinese-BG-Code",
-		"alpha_1": null,
-		"alpha_2b": "zht",
-		"incompatibility": []
-	},
-	"croatian": {
-		"name": "Croatian",
-		"alpha_1": "hr",
-		"alpha_2b": "hrv",
-		"incompatibility": []
-	},
-	"czech": {
-		"name": "Czech",
-		"alpha_1": "cs",
-		"alpha_2b": "cze",
-		"incompatibility": []
-	},
-	"danish": {
-		"name": "Danish",
-		"alpha_1": "da",
-		"alpha_2b": "dan",
-		"incompatibility": []
-	},
-	"dutch": {
-		"name": "Dutch",
-		"alpha_1": "nl",
-		"alpha_2b": "dut",
-		"incompatibility": []
-	},
-	"dutch_english": {
-		"name": "Dutch-English",
-		"alpha_1": null,
-		"alpha_2b": null,
-		"incompatibility": ["opensubtitles"]
-	},
-	"english": {
-		"name": "English",
-		"alpha_1": "en",
-		"alpha_2b": "eng",
-		"incompatibility": []
-	},
-	"english_german": {
-		"name": "English-German",
-		"alpha_1": null,
-		"alpha_2b": null,
-		"incompatibility": ["opensubtitles"]
-	},
-	"esperanto": {
-		"name": "Esperanto",
-		"alpha_1": "eo",
-		"alpha_2b": "epo",
-		"incompatibility": []
-	},
-	"estonian": {
-		"name": "Estonian",
-		"alpha_1": "et",
-		"alpha_2b": "est",
-		"incompatibility": []
-	},
-	"finnish": {
-		"name": "Finnish",
-		"alpha_1": "fi",
-		"alpha_2b": "fin",
-		"incompatibility": []
-	},
-	"french": {
-		"name": "French",
-		"alpha_1": "fr",
-		"alpha_2b": "fre",
-		"incompatibility": []
-	},
-	"georgian": {
-		"name": "Georgian",
-		"alpha_1": "ka",
-		"alpha_2b": "geo",
-		"incompatibility": []
-	},
-	"german": {
-		"name": "German",
-		"alpha_1": "de",
-		"alpha_2b": "ger",
-		"incompatibility": []
-	},
-	"greenlandic": {
-		"name": "Greenlandic",
-		"alpha_1": "kl",
-		"alpha_2b": "kal",
-		"incompatibility": ["opensubtitles"]
-	},
-	"hebrew": {
-		"name": "Hebrew",
-		"alpha_1": "he",
-		"alpha_2b": "heb",
-		"incompatibility": []
-	},
-	"hindi": {
-		"name": "Hindi",
-		"alpha_1": "hi",
-		"alpha_2b": "hin",
-		"incompatibility": []
-	},
-	"hungarian": {
-		"name": "Hungarian",
-		"alpha_1": "hu",
-		"alpha_2b": "hun",
-		"incompatibility": []
-	},
-	"hungarian_english": {
-		"name": "Hungarian-English",
-		"alpha_1": null,
-		"alpha_2b": null,
-		"incompatibility": ["opensubtitles", "yifisubtitles"]
-	},
-	"icelandic": {
-		"name": "Icelandic",
-		"alpha_1": "is",
-		"alpha_2b": "ice",
-		"incompatibility": []
-	},
-	"indonesian": {
-		"name": "Indonesian",
-		"alpha_1": "name",
-		"alpha_2b": "ind",
-		"incompatibility": []
-	},
-	"italian": {
-		"name": "Italian",
-		"alpha_1": "it",
-		"alpha_2b": "ita",
-		"incompatibility": []
-	},
-	"japanese": {
-		"name": "Japanese",
-		"alpha_1": "ja",
-		"alpha_2b": "jpn",
-		"incompatibility": []
-	},
-	"kannada": {
-		"name": "Kannada",
-		"alpha_1": "kn",
-		"alpha_2b": "kan",
-		"incompatibility": []
-	},
-	"kinyarwanda": {
-		"name": "Kinyarwanda",
-		"alpha_1": "rw",
-		"alpha_2b": "kin",
-		"incompatibility": ["opensubtitles", "yifisubtitles"]
-	},
-	"korean": {
-		"name": "Korean",
-		"alpha_1": "ko",
-		"alpha_2b": "kor",
-		"incompatibility": []
-	},
-	"kurdish": {
-		"name": "Kurdish",
-		"alpha_1": "ku",
-		"alpha_2b": "kur",
-		"incompatibility": []
-	},
-	"latvian": {
-		"name": "Latvian",
-		"alpha_1": "lv",
-		"alpha_2b": "lav",
-		"incompatibility": []
-	},
-	"lithuanian": {
-		"name": "Lithuanian",
-		"alpha_1": "lt",
-		"alpha_2b": "lit",
-		"incompatibility": []
-	},
-	"macedonian": {
-		"name": "Macedonian",
-		"alpha_1": "mk",
-		"alpha_2b": "mac",
-		"incompatibility": []
-	},
-	"malayalam": {
-		"name": "Malayalam",
-		"alpha_1": "ml",
-		"alpha_2b": "mal",
-		"incompatibility": []
-	},
-	"manipuri": {
-		"name": "Manipuri",
-		"alpha_1": "mni",
-		"alpha_2b": "mni",
-		"incompatibility": []
-	},
-	"mongolian": {
-		"name": "Mongolian",
-		"alpha_1": "mn",
-		"alpha_2b": "mon",
-		"incompatibility": []
-	},
-	"nepali": {
-		"name": "Nepali",
-		"alpha_1": "ne",
-		"alpha_2b": "nep",
-		"incompatibility": []
-	},
-	"norwegian": {
-		"name": "Norwegian",
-		"alpha_1": "no",
-		"alpha_2b": "nor",
-		"incompatibility": []
-	},
-	"pashto": {
-		"name": "Pashto",
-		"alpha_1": "ps",
-		"alpha_2b": "pus",
-		"incompatibility": ["opensubtitles"]
-	},
-	"punjabi": {
-		"name": "Punjabi",
-		"alpha_1": "pa",
-		"alpha_2b": "pan",
-		"incompatibility": ["opensubtitles", "yifisubtitles"]
-	},
-	"romanian": {
-		"name": "Romanian",
-		"alpha_1": "ro",
-		"alpha_2b": "rum",
-		"incompatibility": []
-	},
-	"russian": {
-		"name": "Russian",
-		"alpha_1": "ru",
-		"alpha_2b": "rus",
-		"incompatibility": []
-	},
-	"serbian": {
-		"name": "Serbian",
-		"alpha_1": "sr",
-		"alpha_2b": "scc",
-		"incompatibility": []
-	},
-	"sinhala": {
-		"name": "Sinhala",
-		"alpha_1": "si",
-		"alpha_2b": "sin",
-		"incompatibility": []
-	},
-	"slovak": {
-		"name": "Slovak",
-		"alpha_1": "sk",
-		"alpha_2b": "slo",
-		"incompatibility": []
-	},
-	"slovenian": {
-		"name": "Slovenian",
-		"alpha_1": "sl",
-		"alpha_2b": "slv",
-		"incompatibility": []
-	},
-	"somali": {
-		"name": "Somali",
-		"alpha_1": "so",
-		"alpha_2b": "som",
-		"incompatibility": []
-	},
-	"spanish": {
-		"name": "Spanish",
-		"alpha_1": "es",
-		"alpha_2b": "spa",
-		"incompatibility": []
-	},
-	"sundanese": {
-		"name": "Sundanese",
-		"alpha_1": "su",
-		"alpha_2b": "sun",
-		"incompatibility": []
-	},
-	"swahili": {
-		"name": "Swahili",
-		"alpha_1": "sw",
-		"alpha_2b": "swa",
-		"incompatibility": []
-	},
-	"swedish": {
-		"name": "Swedish",
-		"alpha_1": "sv",
-		"alpha_2b": "swe",
-		"incompatibility": []
-	},
-	"tagalog": {
-		"name": "Tagalog",
-		"alpha_1": "tl",
-		"alpha_2b": "tgl",
-		"incompatibility": []
-	},
-	"tamil": {
-		"name": "Tamil",
-		"alpha_1": "ta",
-		"alpha_2b": "tam",
-		"incompatibility": []
-	},
-	"telugu": {
-		"name": "Telugu",
-		"alpha_1": "te",
-		"alpha_2b": "tel",
-		"incompatibility": []
-	},
-	"thai": {
-		"name": "Thai",
-		"alpha_1": "th",
-		"alpha_2b": "tha",
-		"incompatibility": []
-	},
-	"turkish": {
-		"name": "Turkish",
-		"alpha_1": "tr",
-		"alpha_2b": "tur",
-		"incompatibility": []
-	},
-	"ukrainian": {
-		"name": "Ukrainian",
-		"alpha_1": "uk",
-		"alpha_2b": "ukr",
-		"incompatibility": []
-	},
-	"urdu": {
-		"name": "Urdu",
-		"alpha_1": "ur",
-		"alpha_2b": "urd",
-		"incompatibility": []
-	},
-	"vietnamese": {
-		"name": "Vietnamese",
-		"alpha_1": "vi",
-		"alpha_2b": "vie",
-		"incompatibility": []
-	},
-	"yoruba": {
-		"name": "Yoruba",
-		"alpha_1": "yo",
-		"alpha_2b": "yor",
-		"incompatibility": ["opensubtitles", "yifisubtitles"]
-	}
+    "albanian": {
+        "name": "Albanian",
+        "alpha_1": "sq",
+        "alpha_2b": "alb",
+        "incompatibility": [],
+        "subscene_id": 1
+    },
+    "arabic": {
+        "name": "Arabic",
+        "alpha_1": "ar",
+        "alpha_2b": "ara",
+        "incompatibility": [],
+        "subscene_id": 2
+    },
+    "armenian": {
+        "name": "Armenian",
+        "alpha_1": "hy",
+        "alpha_2b": "arm",
+        "incompatibility": [],
+        "subscene_id": 73
+    },
+    "azerbaijani": {
+        "name": "Azerbaijani",
+        "alpha_1": "az",
+        "alpha_2b": "aze",
+        "incompatibility": [],
+        "subscene_id": 55
+    },
+    "basque": {
+        "name": "Basque",
+        "alpha_1": "eu",
+        "alpha_2b": "baq",
+        "incompatibility": [],
+        "subscene_id": 74
+    },
+    "belarusian": {
+        "name": "Belarusian",
+        "alpha_1": "be",
+        "alpha_2b": "bel",
+        "incompatibility": [],
+        "subscene_id": 68
+    },
+    "bosnian": {
+        "name": "Bosnian",
+        "alpha_1": "bs",
+        "alpha_2b": "bos",
+        "incompatibility": [],
+        "subscene_id": 60
+    },
+    "brazillian_portuguese": {
+        "name": "Brazillian-Portuguese",
+        "alpha_1": "pt",
+        "alpha_2b": "pob",
+        "incompatibility": [],
+        "subscene_id": 4
+    },
+    "bulgarian": {
+        "name": "Bulgarian",
+        "alpha_1": "bg",
+        "alpha_2b": "bul",
+        "incompatibility": [],
+        "subscene_id": 5
+    },
+    "bulgarian_english": {
+        "name": "Bulgarian-English",
+        "alpha_1": null,
+        "alpha_2b": null,
+        "incompatibility": [
+            "opensubtitles"
+        ],
+        "subscene_id": 6
+    },
+    "burmese": {
+        "name": "Burmese",
+        "alpha_1": "my",
+        "alpha_2b": "bur",
+        "incompatibility": [],
+        "subscene_id": 61
+    },
+    "cambodian_khmer": {
+        "name": "Cambodian-Khmer",
+        "alpha_1": "km",
+        "alpha_2b": "khm",
+        "incompatibility": [],
+        "subscene_id": null
+    },
+    "catalan": {
+        "name": "Catalan",
+        "alpha_1": "ca",
+        "alpha_2b": "cat",
+        "incompatibility": [],
+        "subscene_id": 49
+    },
+    "chinese_bg_code": {
+        "name": "Chinese-BG-Code",
+        "alpha_1": null,
+        "alpha_2b": "zht",
+        "incompatibility": [],
+        "subscene_id": 7
+    },
+    "croatian": {
+        "name": "Croatian",
+        "alpha_1": "hr",
+        "alpha_2b": "hrv",
+        "incompatibility": [],
+        "subscene_id": 8
+    },
+    "czech": {
+        "name": "Czech",
+        "alpha_1": "cs",
+        "alpha_2b": "cze",
+        "incompatibility": [],
+        "subscene_id": 9
+    },
+    "danish": {
+        "name": "Danish",
+        "alpha_1": "da",
+        "alpha_2b": "dan",
+        "incompatibility": [],
+        "subscene_id": 10
+    },
+    "dutch": {
+        "name": "Dutch",
+        "alpha_1": "nl",
+        "alpha_2b": "dut",
+        "incompatibility": [],
+        "subscene_id": 11
+    },
+    "dutch_english": {
+        "name": "Dutch-English",
+        "alpha_1": null,
+        "alpha_2b": null,
+        "incompatibility": [
+            "opensubtitles"
+        ],
+        "subscene_id": 12
+    },
+    "english": {
+        "name": "English",
+        "alpha_1": "en",
+        "alpha_2b": "eng",
+        "incompatibility": [],
+        "subscene_id": 13
+    },
+    "english_german": {
+        "name": "English-German",
+        "alpha_1": null,
+        "alpha_2b": null,
+        "incompatibility": [
+            "opensubtitles"
+        ],
+        "subscene_id": 15
+    },
+    "esperanto": {
+        "name": "Esperanto",
+        "alpha_1": "eo",
+        "alpha_2b": "epo",
+        "incompatibility": [],
+        "subscene_id": 47
+    },
+    "estonian": {
+        "name": "Estonian",
+        "alpha_1": "et",
+        "alpha_2b": "est",
+        "incompatibility": [],
+        "subscene_id": 16
+    },
+    "finnish": {
+        "name": "Finnish",
+        "alpha_1": "fi",
+        "alpha_2b": "fin",
+        "incompatibility": [],
+        "subscene_id": 17
+    },
+    "french": {
+        "name": "French",
+        "alpha_1": "fr",
+        "alpha_2b": "fre",
+        "incompatibility": [],
+        "subscene_id": 18
+    },
+    "georgian": {
+        "name": "Georgian",
+        "alpha_1": "ka",
+        "alpha_2b": "geo",
+        "incompatibility": [],
+        "subscene_id": 62
+    },
+    "german": {
+        "name": "German",
+        "alpha_1": "de",
+        "alpha_2b": "ger",
+        "incompatibility": [],
+        "subscene_id": 19
+    },
+    "greenlandic": {
+        "name": "Greenlandic",
+        "alpha_1": "kl",
+        "alpha_2b": "kal",
+        "incompatibility": [
+            "opensubtitles"
+        ],
+        "subscene_id": 57
+    },
+    "hebrew": {
+        "name": "Hebrew",
+        "alpha_1": "he",
+        "alpha_2b": "heb",
+        "incompatibility": [],
+        "subscene_id": 22
+    },
+    "hindi": {
+        "name": "Hindi",
+        "alpha_1": "hi",
+        "alpha_2b": "hin",
+        "incompatibility": [],
+        "subscene_id": 51
+    },
+    "hungarian": {
+        "name": "Hungarian",
+        "alpha_1": "hu",
+        "alpha_2b": "hun",
+        "incompatibility": [],
+        "subscene_id": 23
+    },
+    "hungarian_english": {
+        "name": "Hungarian-English",
+        "alpha_1": null,
+        "alpha_2b": null,
+        "incompatibility": [
+            "opensubtitles",
+            "yifisubtitles"
+        ],
+        "subscene_id": 24
+    },
+    "icelandic": {
+        "name": "Icelandic",
+        "alpha_1": "is",
+        "alpha_2b": "ice",
+        "incompatibility": [],
+        "subscene_id": 25
+    },
+    "indonesian": {
+        "name": "Indonesian",
+        "alpha_1": "name",
+        "alpha_2b": "ind",
+        "incompatibility": [],
+        "subscene_id": 44
+    },
+    "italian": {
+        "name": "Italian",
+        "alpha_1": "it",
+        "alpha_2b": "ita",
+        "incompatibility": [],
+        "subscene_id": 26
+    },
+    "japanese": {
+        "name": "Japanese",
+        "alpha_1": "ja",
+        "alpha_2b": "jpn",
+        "incompatibility": [],
+        "subscene_id": 27
+    },
+    "kannada": {
+        "name": "Kannada",
+        "alpha_1": "kn",
+        "alpha_2b": "kan",
+        "incompatibility": [],
+        "subscene_id": 78
+    },
+    "kinyarwanda": {
+        "name": "Kinyarwanda",
+        "alpha_1": "rw",
+        "alpha_2b": "kin",
+        "incompatibility": [
+            "opensubtitles",
+            "yifisubtitles"
+        ],
+        "subscene_id": 81
+    },
+    "korean": {
+        "name": "Korean",
+        "alpha_1": "ko",
+        "alpha_2b": "kor",
+        "incompatibility": [],
+        "subscene_id": 28
+    },
+    "kurdish": {
+        "name": "Kurdish",
+        "alpha_1": "ku",
+        "alpha_2b": "kur",
+        "incompatibility": [],
+        "subscene_id": 52
+    },
+    "latvian": {
+        "name": "Latvian",
+        "alpha_1": "lv",
+        "alpha_2b": "lav",
+        "incompatibility": [],
+        "subscene_id": 29
+    },
+    "lithuanian": {
+        "name": "Lithuanian",
+        "alpha_1": "lt",
+        "alpha_2b": "lit",
+        "incompatibility": [],
+        "subscene_id": 43
+    },
+    "macedonian": {
+        "name": "Macedonian",
+        "alpha_1": "mk",
+        "alpha_2b": "mac",
+        "incompatibility": [],
+        "subscene_id": 48
+    },
+    "malayalam": {
+        "name": "Malayalam",
+        "alpha_1": "ml",
+        "alpha_2b": "mal",
+        "incompatibility": [],
+        "subscene_id": 64
+    },
+    "manipuri": {
+        "name": "Manipuri",
+        "alpha_1": "mni",
+        "alpha_2b": "mni",
+        "incompatibility": [],
+        "subscene_id": 65
+    },
+    "mongolian": {
+        "name": "Mongolian",
+        "alpha_1": "mn",
+        "alpha_2b": "mon",
+        "incompatibility": [],
+        "subscene_id": 72
+    },
+    "nepali": {
+        "name": "Nepali",
+        "alpha_1": "ne",
+        "alpha_2b": "nep",
+        "incompatibility": [],
+        "subscene_id": 80
+    },
+    "norwegian": {
+        "name": "Norwegian",
+        "alpha_1": "no",
+        "alpha_2b": "nor",
+        "incompatibility": [],
+        "subscene_id": 30
+    },
+    "pashto": {
+        "name": "Pashto",
+        "alpha_1": "ps",
+        "alpha_2b": "pus",
+        "incompatibility": [
+            "opensubtitles"
+        ],
+        "subscene_id": 67
+    },
+    "punjabi": {
+        "name": "Punjabi",
+        "alpha_1": "pa",
+        "alpha_2b": "pan",
+        "incompatibility": [
+            "opensubtitles",
+            "yifisubtitles"
+        ],
+        "subscene_id": 66
+    },
+    "romanian": {
+        "name": "Romanian",
+        "alpha_1": "ro",
+        "alpha_2b": "rum",
+        "incompatibility": [],
+        "subscene_id": 33
+    },
+    "russian": {
+        "name": "Russian",
+        "alpha_1": "ru",
+        "alpha_2b": "rus",
+        "incompatibility": [],
+        "subscene_id": 34
+    },
+    "serbian": {
+        "name": "Serbian",
+        "alpha_1": "sr",
+        "alpha_2b": "scc",
+        "incompatibility": [],
+        "subscene_id": 35
+    },
+    "sinhala": {
+        "name": "Sinhala",
+        "alpha_1": "si",
+        "alpha_2b": "sin",
+        "incompatibility": [],
+        "subscene_id": 58
+    },
+    "slovak": {
+        "name": "Slovak",
+        "alpha_1": "sk",
+        "alpha_2b": "slo",
+        "incompatibility": [],
+        "subscene_id": 36
+    },
+    "slovenian": {
+        "name": "Slovenian",
+        "alpha_1": "sl",
+        "alpha_2b": "slv",
+        "incompatibility": [],
+        "subscene_id": 37
+    },
+    "somali": {
+        "name": "Somali",
+        "alpha_1": "so",
+        "alpha_2b": "som",
+        "incompatibility": [],
+        "subscene_id": 70
+    },
+    "spanish": {
+        "name": "Spanish",
+        "alpha_1": "es",
+        "alpha_2b": "spa",
+        "incompatibility": [],
+        "subscene_id": 38
+    },
+    "sundanese": {
+        "name": "Sundanese",
+        "alpha_1": "su",
+        "alpha_2b": "sun",
+        "incompatibility": [],
+        "subscene_id": 76
+    },
+    "swahili": {
+        "name": "Swahili",
+        "alpha_1": "sw",
+        "alpha_2b": "swa",
+        "incompatibility": [],
+        "subscene_id": 75
+    },
+    "swedish": {
+        "name": "Swedish",
+        "alpha_1": "sv",
+        "alpha_2b": "swe",
+        "incompatibility": [],
+        "subscene_id": 39
+    },
+    "tagalog": {
+        "name": "Tagalog",
+        "alpha_1": "tl",
+        "alpha_2b": "tgl",
+        "incompatibility": [],
+        "subscene_id": 53
+    },
+    "tamil": {
+        "name": "Tamil",
+        "alpha_1": "ta",
+        "alpha_2b": "tam",
+        "incompatibility": [],
+        "subscene_id": 59
+    },
+    "telugu": {
+        "name": "Telugu",
+        "alpha_1": "te",
+        "alpha_2b": "tel",
+        "incompatibility": [],
+        "subscene_id": 63
+    },
+    "thai": {
+        "name": "Thai",
+        "alpha_1": "th",
+        "alpha_2b": "tha",
+        "incompatibility": [],
+        "subscene_id": 40
+    },
+    "turkish": {
+        "name": "Turkish",
+        "alpha_1": "tr",
+        "alpha_2b": "tur",
+        "incompatibility": [],
+        "subscene_id": 41
+    },
+    "ukrainian": {
+        "name": "Ukrainian",
+        "alpha_1": "uk",
+        "alpha_2b": "ukr",
+        "incompatibility": [],
+        "subscene_id": 56
+    },
+    "urdu": {
+        "name": "Urdu",
+        "alpha_1": "ur",
+        "alpha_2b": "urd",
+        "incompatibility": [],
+        "subscene_id": 42
+    },
+    "vietnamese": {
+        "name": "Vietnamese",
+        "alpha_1": "vi",
+        "alpha_2b": "vie",
+        "incompatibility": [],
+        "subscene_id": 45
+    },
+    "yoruba": {
+        "name": "Yoruba",
+        "alpha_1": "yo",
+        "alpha_2b": "yor",
+        "incompatibility": [
+            "opensubtitles",
+            "yifisubtitles"
+        ],
+        "subscene_id": 71
+    }
 }

--- a/src/subsearch/data/languages.json
+++ b/src/subsearch/data/languages.json
@@ -83,7 +83,7 @@
         "alpha_1": "km",
         "alpha_2b": "khm",
         "incompatibility": [],
-        "subscene_id": null
+        "subscene_id": 79
     },
     "catalan": {
         "name": "Catalan",

--- a/src/subsearch/gui/tab_manager.py
+++ b/src/subsearch/gui/tab_manager.py
@@ -114,6 +114,7 @@ class TabSearch(tk.Frame):
         tk.Frame(self, height=80, bg=GUI_DATA.colors.dark_grey).pack(anchor="center", expand=True)
         search_tab.SubtitleType(self).pack(anchor="center")
         search_tab.SearchThreshold(self).pack(anchor="center")
+        search_tab.ForeignOnly(self).pack(anchor="center")
         search_tab.RenameBestMatch(self).pack(anchor="center")
 
 

--- a/src/subsearch/gui/tabs/search_tab.py
+++ b/src/subsearch/gui/tabs/search_tab.py
@@ -221,7 +221,7 @@ class ForeignOnly(tkinter_utils.ToggleableFrameButton):
     """
 
     def __init__(self, parent) -> None:
-        tkinter_utils.ToggleableFrameButton.__init__(self, parent, "Foreign language only", "foreign_only")
+        tkinter_utils.ToggleableFrameButton.__init__(self, parent, "Foreign language only", "foreign_only", tip_text="If True, only 'Subscene.com' will be used.")
 
 
 class RenameBestMatch(tkinter_utils.ToggleableFrameButton):

--- a/src/subsearch/gui/tabs/search_tab.py
+++ b/src/subsearch/gui/tabs/search_tab.py
@@ -221,7 +221,8 @@ class ForeignOnly(tkinter_utils.ToggleableFrameButton):
     """
 
     def __init__(self, parent) -> None:
-        tkinter_utils.ToggleableFrameButton.__init__(self, parent, "Foreign language only", "foreign_only", tip_text="If True, only 'Subscene.com' will be used.")
+        text = f"If 'True', 'OpenSubtitles, Yifysubtitles' will be automatically skipped."
+        tkinter_utils.ToggleableFrameButton.__init__(self, parent, "Foreign language only", "foreign_only", tip_text=text)
 
 
 class RenameBestMatch(tkinter_utils.ToggleableFrameButton):

--- a/src/subsearch/gui/tabs/search_tab.py
+++ b/src/subsearch/gui/tabs/search_tab.py
@@ -213,6 +213,17 @@ class SearchThreshold(tk.Frame):
         tkinter_utils.VarColorPicker(self.string_var, self.clabel, True)
 
 
+class ForeignOnly(tkinter_utils.ToggleableFrameButton):
+    """
+    Inherits from the tk_tools.ToggleableFrameButton class and create toggleable button widget with different settings.
+
+    Class corresponds to a specific setting in the configuration file and has a unique label, configuration key, and other optional attributes.
+    """
+
+    def __init__(self, parent) -> None:
+        tkinter_utils.ToggleableFrameButton.__init__(self, parent, "Foreign language only", "foreign_only")
+
+
 class RenameBestMatch(tkinter_utils.ToggleableFrameButton):
     """
     Inherits from the tk_tools.ToggleableFrameButton class and create toggleable button widget with different settings.

--- a/src/subsearch/gui/tkinter_utils.py
+++ b/src/subsearch/gui/tkinter_utils.py
@@ -314,7 +314,9 @@ class ToggleableFrameButton(tk.Frame):
         show_if_exe (bool, optional): Only show the button if the program is not running from an executable. Defaults to True.
     """
 
-    def __init__(self, parent, setting_label: str, config_key: str, write_to_reg: bool = False, show_if_exe=True) -> None:
+    def __init__(
+        self, parent, setting_label: str, config_key: str, write_to_reg: bool = False, show_if_exe=True, tip_text=None
+    ) -> None:
         tk.Frame.__init__(self, parent)
         self.configure(bg=GUI_DATA.colors.dark_grey)
         self.string_var = tk.StringVar()
@@ -323,6 +325,8 @@ class ToggleableFrameButton(tk.Frame):
         self.config_key = config_key
         self.write_to_reg = write_to_reg
         self.show_if_exe = show_if_exe
+        self.tip_text = tip_text
+        self.tip_present = False
         if show_if_exe is False and file_manager.running_from_exe():
             return None
         label = tk.Label(self, text=self.setting_name)
@@ -351,6 +355,10 @@ class ToggleableFrameButton(tk.Frame):
             btn.bind("<ButtonRelease-1>", self.button_set_false)
         if btn["text"] == "False":
             btn.bind("<ButtonRelease-1>", self.button_set_true)
+        if self.tip_text is not None and self.tip_present is False:
+            self.tip = ToolTip(btn, btn, self.tip_text)
+            self.tip.show()
+            self.tip_present = True
 
     def leave_button(self, event) -> None:
         """
@@ -360,6 +368,9 @@ class ToggleableFrameButton(tk.Frame):
             event: The tkinter event object.
         """
         btn = event.widget
+        if self.tip_present:
+            self.tip.hide()
+            self.tip_present = False
 
     def button_set_true(self, event) -> None:
         """

--- a/src/subsearch/providers/subscene.py
+++ b/src/subsearch/providers/subscene.py
@@ -42,6 +42,8 @@ class SubsceneScraper:
             if self.skip_item(item, hi_sub, regular_sub):
                 continue
             node = item.css_first("a")
+            if node.child.text_content == "upload":
+                continue
             subtitle_href = node.attributes["href"]
             filename = item.css_first("span:nth-child(2)").child.text_content.strip()
             subtitles[filename] = f"https://subscene.com{subtitle_href}"
@@ -69,7 +71,8 @@ class Subscene(ProviderParameters, SubsceneScraper):
         to_be_sorted: list[PrettifiedDownloadData] = []
         _to_be_downloaded: dict[str, str] = {}
         to_be_downloaded: dict[str, str] = {}
-
+        custom_subscene_header = generic.CustomSubsceneHeader(self.app_config)
+        header = custom_subscene_header.create_header()
         # find title
         definitive_match = self._definitive_match()
         found_title_url = self.find_title(self.url_subscene, self.current_language, definitive_match)
@@ -77,8 +80,6 @@ class Subscene(ProviderParameters, SubsceneScraper):
             return []
 
         # search for subtitles
-        custom_subscene_header = generic.CustomSubsceneHeader(self.app_config)
-        header = custom_subscene_header.create_header()
         subtitle_data = self.find_subtitles(found_title_url, self.hi_sub, self.non_hi_sub, header)
         for key, value in subtitle_data.items():
             pct_result = string_parser.calculate_match(key, self.release)

--- a/src/subsearch/providers/subscene.py
+++ b/src/subsearch/providers/subscene.py
@@ -34,9 +34,9 @@ class SubsceneScraper:
             return True
         return False
 
-    def find_subtitles(self, url: str, hi_sub: bool, regular_sub: bool) -> dict[str, str]:
+    def find_subtitles(self, url: str, hi_sub: bool, regular_sub: bool, subscene_header) -> dict[str, str]:
         subtitles: dict[str, str] = {}
-        tree = generic.get_html_parser(url)
+        tree = generic.get_html_parser(url, subscene_header)
         products = tree.css("tr")
         for item in products[1:]:
             if self.skip_item(item, hi_sub, regular_sub):
@@ -77,7 +77,9 @@ class Subscene(ProviderParameters, SubsceneScraper):
             return []
 
         # search for subtitles
-        subtitle_data = self.find_subtitles(found_title_url, self.hi_sub, self.non_hi_sub)
+        custom_subscene_header = generic.CustomSubsceneHeader(self.app_config)
+        header = custom_subscene_header.create_header()
+        subtitle_data = self.find_subtitles(found_title_url, self.hi_sub, self.non_hi_sub, header)
         for key, value in subtitle_data.items():
             pct_result = string_parser.calculate_match(key, self.release)
             log.output_match("subscene", pct_result, key)

--- a/src/subsearch/utils/io_json.py
+++ b/src/subsearch/utils/io_json.py
@@ -91,6 +91,7 @@ def create_application_config() -> None:
     data = {}
     data["current_language"] = "english"
     data["subtitle_type"] = dict.fromkeys(subtitle_types, True)
+    data["foreign_only"] = False
     data["percentage_threshold"] = 90
     data["rename_best_match"] = True
     data["context_menu"] = True
@@ -142,6 +143,11 @@ def get_language_data(language: str = "default") -> LanguageData:
     data = get_json_data(LANGS_JSON)
     language_data = LanguageData(**data[language])
     return language_data
+
+
+def get_language_data_value(key: str):
+    data = get_language_data()
+    return data[key]
 
 
 def get_available_languages() -> dict:


### PR DESCRIPTION
- Added a new configuration option for filtering subtitles by foreign languages only.
- Implemented the UI component for toggling the foreign language filter.
- Updated the Subscene provider to send the foreign language filter value in the request header.
- Created a new SubsceneCookie data class to store the configuration values related to Subscene.
- Updated the AppConfig data class to include the foreign_only attribute.
- Added the foreign_only attribute to the application configuration JSON file.
- Modified the JSON I/O functions to handle the new attribute.