### PR TITLE
Exception Handling for KeyError in mutex_synchronizer

### DIFF
--- a/src/subsearch/utils/mutex_synchronizer.py
+++ b/src/subsearch/utils/mutex_synchronizer.py
@@ -27,6 +27,8 @@ def synchronized(mutex_name: str) -> Callable:
                     return func()
             except FileNotFoundError:
                 pass
+            except KeyError:
+                pass
             kernel32 = ctypes.WinDLL("kernel32")
             mutex = kernel32.CreateMutexW(None, False, mutex_name)
             last_error = kernel32.GetLastError()


### PR DESCRIPTION
This pull request adds exception handling for KeyError in the mutex_synchronizer.py module. The module was being used before the multiple_app_instances key can be written if missing.