### PR TITLE
Exception Handling for KeyError in log

### DIFF
--- a/src/subsearch/utils/log.py
+++ b/src/subsearch/utils/log.py
@@ -16,9 +16,12 @@ from subsearch.utils import io_json
 
 NOW = datetime.now()
 DATE = NOW.strftime("%y%m%d")
+
 try:
     LOG_TO_FILE = io_json.get_json_key("log_to_file")
 except FileNotFoundError:
+    pass
+except KeyError:
     pass
 
 lock = Lock()


### PR DESCRIPTION
This pull request adds exception handling for KeyError in the log.py module. The module was being used before the `log_to_file` key can be written if missing.