### PR TITLE
Create hashes.256 file in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,14 +227,12 @@ jobs:
         run: |
           $pre_releases = @('rc', 'a', 'b')
           $is_pre_release = $null -ne ($pre_releases | ? { "${{ github.ref_name }}" -match $_ })
-          $sha256_hash = Get-FileHash -Path "Subsearch-${{ needs.variables.outputs.valid_semver }}-win64.msi" -Algorithm SHA256 | Select-Object -ExpandProperty Hash
           $subsearch_repo = "https://github.com/vagabondHustler/subsearch"
           $virustotal_no_file = "VirusTotal analysis: No file uploaded"
           $virustotal_url = "VirusTotal analysis: [Subsearch-${{ needs.variables.outputs.valid_semver }}-win64.msi](https://www.virustotal.com/gui/file/$sha256_hash)"
           if ($is_pre_release){$virustotal_analysis = $virustotal_no_file} else {$virustotal_analysis = $virustotal_url}
           $comparison_link = "[${{ github.ref_name }}]($subsearch_repo/compare/${{  needs.variables.outputs.past_ref_name }}...${{ github.ref_name }})"
           $full_changelog = "Full changelog: $comparison_link"
-          $hash_info = "<p>SHA256: $sha256_hash"
           if ($is_pre_release) {
             echo "${{ steps.changelog_pre_release.outputs.changelog }}" > changelog-${{ needs.variables.outputs.valid_semver }}.md
           } else {
@@ -277,6 +275,31 @@ jobs:
           name: Subsearch-${{ needs.variables.outputs.valid_semver }}-win64.msi
           path: .
 
+      - name: Create hashes256
+        id: hashes
+        run: |
+          $filenames = @(
+            "tox.ini"
+            "tox.ini"
+          )
+
+          $hashAlgorithm = "SHA256"
+          $targetFilePath = "hashes.256"
+
+          foreach ($filename in $filenames) {
+            $filePath = $filename
+            $hash = Get-FileHash -Path $filePath -Algorithm $hashAlgorithm | Select-Object -ExpandProperty Hash
+            $line = "$hash *$filename"
+
+            $line | Out-File -FilePath $targetFilePath -Append
+          }
+
+      - name: Upload hashes256 artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: hashes256
+          path: hashes.256
+
       - name: Publish release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -286,6 +309,7 @@ jobs:
           token: ${{ secrets.ACTIONS_TOKEN }}
           prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'b') || contains(github.ref_name, 'a') }}
           files: |
+            hashes.256
             Subsearch-${{ needs.variables.outputs.valid_semver }}-win64.msi
 
   publish_pypi:
@@ -346,4 +370,3 @@ jobs:
           git commit -S -m "Chore update latest_release.yml"
           git fetch origin main
           git push origin HEAD:main
-


### PR DESCRIPTION
- Removed the line that calculates the SHA256 hash of the MSI file.
- Added a step to create SHA256 hashes for specified files.
- Added a step to upload the hashes256 artifact.
- Updated the "Publish release" step to include the hashes256 artifact in the release files.
- Removed an empty line at the end of the file.