### PR TITLE
Fix options in GUI not applying

### DIFF
--- a/src/subsearch/gui/screens/search_filters.py
+++ b/src/subsearch/gui/screens/search_filters.py
@@ -73,17 +73,17 @@ class SubtitleOptions(ttk.Labelframe):
         self.configure(text="Subtitle Options", padding=10)
         self.data = io_json.get_json_data()
         self.subtitle_options: dict = {
-            "hearing_impaired": ["Include hearing impaird subtitles"],
-            "non_hearing_impaired": ["Include regular subtitles"],
-            "foreign_only": ["Only include subtitles for foreign parts"],
-            "rename_best_match": ["Rename best match for 'Autoload'"],
+            "hearing_impaired": "Include hearing impaird subtitles",
+            "non_hearing_impaired": "Include regular subtitles",
+            "foreign_only": "Only include subtitles for foreign parts",
+            "rename_best_match": "Rename best match for 'Autoload'",
         }
         for name, description in self.subtitle_options.items():
             if "hearing_impaired" in name:
                 subtitle_type = io_json.get_json_key("subtitle_type")
                 self.subtitle_options[name] = [subtitle_type[name], description]
-                continue
-            self.subtitle_options[name] = [io_json.get_json_key(name), description]
+            else:
+                self.subtitle_options[name] = [io_json.get_json_key(name), description]
         frame = None
         self.checkbuttons: dict[ttk.Checkbutton, tuple[str, tk.BooleanVar]] = {}
         for enum, (key, value) in enumerate(self.subtitle_options.items()):
@@ -113,9 +113,15 @@ class SubtitleOptions(ttk.Labelframe):
         key = self.checkbuttons[btn][0]
         value = self.checkbuttons[btn][1]
         if value.get() is True:
-            self.data["subtitle_type"][key] = False
+            if "hearing_impaired" in key:
+                self.data["subtitle_type"][key] = False
+            else:
+                self.data[key] = False
         elif value.get() is False:
-            self.data["subtitle_type"][key] = True
+            if "hearing_impaired" in key:
+                self.data["subtitle_type"][key] = True
+            else:
+                self.data[key] = True
         io_json.set_json_data(self.data)
 
     def add_missig_json_key(self, name, description):

--- a/src/subsearch/gui/screens/subsearch_options.py
+++ b/src/subsearch/gui/screens/subsearch_options.py
@@ -84,16 +84,16 @@ class SubsearchOption(ttk.Labelframe):
         ttk.Labelframe.__init__(self, parent)
         self.configure(text="Subsearch Options", padding=10)
         self.data = io_json.get_json_data()
-        self.subsearch_options: dict[str, list] = {
-            "context_menu": ["Context menu"],
-            "context_menu_icon": ["Context menu icon"],
-            "system_tray": ["System tray icon"],
-            "toast_summary": ["Notification when done"],
-            "manual_download_fail": ["Manual download on fail"],
-            "show_terminal": ["Terminal while searching"],
-            "log_to_file": ["Create log file"],
-            "use_threading": ["Multithreading"],
-            "multiple_app_instances": ["Multiple instances"],
+        self.subsearch_options = {
+            "context_menu": "Context menu",
+            "context_menu_icon": "Context menu icon",
+            "system_tray": "System tray icon",
+            "toast_summary": "Notification when done",
+            "manual_download_fail": "Manual download on fail",
+            "show_terminal": "Terminal while searching",
+            "log_to_file": "Create log file",
+            "use_threading": "Multithreading",
+            "multiple_app_instances": "Multiple instances",
         }
         for name, description in self.subsearch_options.items():
             self.subsearch_options[name] = [io_json.get_json_key(name), description]


### PR DESCRIPTION
- Fixed a bug that prevented the application from saving the user's settings in the subtitle options.
- Adjusted the logic in the `toggle_types` method to correctly update the data values based on the key, ensuring proper saving of the settings.
- Modified the assignment of the label text in the `__init__` method of the `SubtitleOptions` class to remove the extra parentheses.
- Updated the `self.subtitle_options` dictionary initialization in the `__init__` method to fix the displayed label text issue.
- Verified that the user settings are properly saved and applied when toggling the subtitle options.