### PR TITLE
Remove all docstrings from tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ from subsearch.utils import io_app
 
 @pytest.fixture(scope="session")
 def subsearch_app_path():
-    """Fixture to get the path to the subsearch directory."""
     app_path = Path(__file__).parent.parent / "src"
     sys.path.insert(0, str(app_path))
     return app_path
@@ -19,7 +18,6 @@ def subsearch_app_path():
 
 @pytest.fixture(scope="session")
 def cwd():
-    """Fixture to get the path to the subsearch directory."""
     cwd = Path.cwd() / "src"
     sys.path.insert(0, str(cwd))
     return cwd
@@ -27,7 +25,6 @@ def cwd():
 
 @pytest.fixture(scope="session")
 def tests_path():
-    """Fixture to get the path to the tests directory."""
     tests_path = Path(__file__).parent
     sys.path.insert(0, str(tests_path))
     return tests_path
@@ -77,5 +74,4 @@ def override_constants(fake_language_data_file, fake_config_file, fake_log_file)
 
 @pytest.fixture(autouse=True)
 def reset_constants():
-    # Reset the constants to their original values after testing
     importlib.reload(io_app)

--- a/tests/test_io_app.py
+++ b/tests/test_io_app.py
@@ -5,10 +5,6 @@ from subsearch.utils import io_app
 
 
 def test_app_paths() -> None:
-    """Test function for APP_PATHS module.
-
-    This function tests whether various path constants defined in APP_PATHS module are correctly defined.
-    """
     app_paths = io_app.get_app_paths()
     assert app_paths.home.is_dir()
     assert app_paths.data.is_dir()

--- a/tests/test_io_file_system.py
+++ b/tests/test_io_file_system.py
@@ -12,9 +12,6 @@ def test_video_file_none() -> None:
 
 
 def test_get_hash() -> None:
-    """
-    test the get_hash function in src/subsearch/utils/io_file_system.py
-    """
     hash0 = io_file_system.get_file_hash(CWD / "fake.test.movie.2022.1080p-group.mkv")
     hash1 = io_file_system.get_file_hash(CWD / "fake.none.hash.movie.mkv")
     assert hash0 == "43a17047da7e960e"
@@ -22,7 +19,4 @@ def test_get_hash() -> None:
 
 
 def test_got_key() -> None:
-    """
-    test to ensure that the src/subsearch/utils/io_winreg.get_key function returns boolean
-    """
     assert io_winreg.registry_key_exists() or io_winreg.registry_key_exists() is False

--- a/tests/test_string_parser.py
+++ b/tests/test_string_parser.py
@@ -4,9 +4,6 @@ from tests import constants_test
 
 
 def test_str_parser_movie() -> None:
-    """
-    test so to ensure that the src/subsearch/utils/string_parser.pct_value function returns a with the correct percentage
-    """
     movie_1080p = "the.foo.bar.2021.1080p.web.h264-foobar"
     movie_720p = "the.foo.bar.2021.720p.web.h264-foobar"
     show_1080p = "the.foo.bar.s01e01.1080p.web.h264-foobar"
@@ -29,10 +26,6 @@ def test_str_parser_movie() -> None:
 
 
 def test_string_parser_movie() -> None:
-    """
-    test to ensure that the src/subsearch/utils/file_parser.get_parameters function returns the correct parameters for a movie so as to be able to search for subtitles
-    """
-
     filename = "the.foo.bar.2021.1080p.web.h264-foobar"
     release_data = string_parser.get_release_data(filename)
 
@@ -48,9 +41,6 @@ def test_string_parser_movie() -> None:
 
 
 def test_string_parser_show() -> None:
-    """
-    test to ensure that the src/subsearch/utils/file_parser.get_parameters function returns the correct parameters for a show so as to be able to search for subtitles
-    """
     filename = "the.foo.bar.s01e01.1080p.web.h264-foobar"
     release_data = string_parser.get_release_data(filename)
 

--- a/tests/test_utils_version.py
+++ b/tests/test_utils_version.py
@@ -4,9 +4,5 @@ from subsearch.data import __version__
 
 
 def test_current() -> None:
-    """
-    test so to ensure that the src/subsearch/utils/version.current function returns a with the correct format
-    """
-
     version_digits = "".join(re.findall(r"\d+", __version__))
     assert version_digits.isnumeric() is True


### PR DESCRIPTION
- Removed all existing docstrings, as the majority were outdated. Some new docstrings will be incorporated in the future.