### PR TITLE
Fix rollback cx_Freeze version for EXE build issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ optional = [
     "isort==5.12.0",
     "twine==4.0.2",
     "build==1.0.3",
-    "cx_Freeze==6.15.8",
+    "cx_Freeze==6.15.6",
     "mypy==1.5.1",
     "pipreqs==0.4.13",
 ]


### PR DESCRIPTION
- Rolled back cx_Freeze version from 6.15.8 to 6.15.6 in pyproject.toml to address EXE build bug.