### PR TITLE
feat: Install updates directly from GUI

### DIFF
--- a/src/subsearch/core.py
+++ b/src/subsearch/core.py
@@ -57,6 +57,7 @@ class Initializer:
             )
 
     def setup_file_system(self) -> None:
+        io_file_system.del_directory_content(APP_PATHS.tmp_dir)
         io_file_system.create_directory(APP_PATHS.tmp_dir)
         io_file_system.create_directory(APP_PATHS.appdata_subsearch)
         io_toml.resolve_on_integrity_failure()

--- a/src/subsearch/gui/screens/subsearch_options.py
+++ b/src/subsearch/gui/screens/subsearch_options.py
@@ -260,9 +260,16 @@ class CheckForUpdates(ttk.Labelframe):
             text="Open in webbrowser",
             width=20,
         )
+        self.btn_update_install = ttk.Button(
+            frame_right,
+            text="Download & Update",
+            width=20,
+        )
         self.btn_search.pack(padx=2, pady=2)
         self.btn_visit_release_page.pack(padx=2, pady=2)
         self.btn_visit_release_page.state(["disabled"])
+        self.btn_update_install.pack(padx=2, pady=2)
+        self.btn_update_install.state(["disabled"])
         self.btn_search.bind("<Enter>", self.enter_button)
 
         self.pack(anchor="center", fill="x")
@@ -284,6 +291,11 @@ class CheckForUpdates(ttk.Labelframe):
             self.btn_search.state(["disabled"])
             self.btn_visit_release_page.state(["!disabled"])
             self.btn_visit_release_page.bind("<ButtonRelease-1>", self.visit_repository_button)
+            if DEVICE_INFO.mode == "executable": 
+                self.btn_update_install.state(["!disabled"])
+                self.btn_update_install.bind("<ButtonRelease-1>", self.download_and_update)
+            else:
+                self.btn_update_install["text"]="Only availible with MSI"
             if repo_is_prerelease:
                 self.var_misc.set(f"Pre-release")
                 self.frame_misc.configure(fg=cfg.color.orange)
@@ -297,3 +309,7 @@ class CheckForUpdates(ttk.Labelframe):
 
     def visit_repository_button(self, event) -> None:
         webbrowser.open(f"https://github.com/vagabondHustler/subsearch/releases")
+        
+    def download_and_update(self, event) -> None:
+        update.download_and_update()
+        self.btn_visit_release_page.state(["disabled"])

--- a/src/subsearch/utils/update.py
+++ b/src/subsearch/utils/update.py
@@ -1,9 +1,14 @@
+from pathlib import Path
 import re
+import subprocess
 
 import cloudscraper
 from packaging.version import Version
 
-from subsearch.globals.constants import VERSION
+from subsearch.globals.constants import VERSION, APP_PATHS
+import requests
+import sys
+from subsearch.utils import io_file_system, io_log
 
 
 def find_semantic_version(version: str) -> str:
@@ -39,27 +44,35 @@ def is_new_version_avail() -> tuple[bool, bool]:
     return new_repo_avail, repo_is_prerelease
 
 
-# Work in progress
-# def find_sha256(url):
-#     response = requests.get(url)
-#     html_content = response.text
+def get_latest_msi_url(latest_version: str = "") -> str:
+    return f"https://github.com/vagabondHustler/subsearch/releases/download/{latest_version}/Subsearch-{latest_version}-win64.msi"
 
-#     parser = selectolax.parser.HTMLParser(html_content)
-#     selector_lst = [
-#         ".clearfix",
-#         "div:nth-child(3)",
-#         "section:nth-child(1)",
-#         "div:nth-child(2)",
-#         "div:nth-child(2)",
-#         "div:nth-child(1)",
-#         "div:nth-child(1)",
-#         "div:nth-child(2)",
-#         "h6:nth-child(5)",
-#         "p:nth-child(2)",
-#     ]
 
-#     css_selector = " > ".join(selector_lst)
+def run_installer(msi_package_path: Path) -> None:
+    command = f"msiexec.exe /i {msi_package_path}"
+    subprocess.Popen(command, shell=True, creationflags=subprocess.DETACHED_PROCESS)
 
-#     element = parser.css(css_selector)
-#     match = re.search(r"([A-Fa-f0-9]{64})", element[0].html)
-#     return match[0]
+
+def download_and_update():
+    io_log.log.brackets("Updating Application")
+    latest_version = get_latest_version()
+    latest_msi = get_latest_msi_url(latest_version)
+    if Version(VERSION) > Version(latest_version):
+        io_log.log.stdout(f"No new version available")
+        return None
+
+    io_log.log.stdout(f"New version available")
+    if not APP_PATHS.tmp_dir.exists():
+        APP_PATHS.tmp_dir.mkdir(parents=True, exist_ok=True)
+    msi_package_path = APP_PATHS.tmp_dir / f"Subsearch-{latest_version}-win64.msi"
+    response = requests.get(latest_msi, stream=True)
+    if response.status_code == 200:
+        io_file_system.download_response(msi_package_path, response)
+        msg = f"MSI file downloaded to: {msi_package_path}"
+        io_log.log.stdout(f"MSI file downloaded to: {msi_package_path}")
+    else:
+        msg = f"Failed to download MSI file. HTTP Status Code: {response.status_code}"
+        io_log.log.stdout(msg, level="error")
+        raise Exception(response.status_code)
+    run_installer(msi_package_path)
+    sys.exit()


### PR DESCRIPTION
- The user can now update Subsearch within the GUI
- The new option is only available if the user is using the exe/msi version of Subsearch
- The MSI is downloaded to the `tmp_dir` and removed at next launch of the app