### PR TITLE
ci: sync .github folder from dev

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,32 +1,16 @@
-To  streamline the process, please follow the guidelines below.
+# Contributing
 
-#### Suggesting a Feature:
+## Suggesting a Feature
 
-- Check the code on GitHub to ensure that the feature isn't already available.
-- Consider whether the feature is necessary in the library or could be explained in a separate example.
-- Check existing issues, both open and closed, to avoid suggesting a feature that has already been suggested.
+Check existing issues (open and closed) before suggesting. Describe the problem it solves and why it belongs in the core app.
 
-#### Filing a Bug Report:
+## Filing a Bug Report
 
-- Provide a detailed description of the bug.
-- List the steps you've taken so far and any solutions you've tried.
+Include a description of the bug, steps to reproduce, and what you tried.
 
-Submitting a Pull Request:
+## Submitting a Pull Request
 
-- Ensure that your code style is consistent with ours (we follow the black style guidelines for Python).
-- Include comments where necessary and a clear description of what your example is expected to do.
-- Submit only one or two examples/feature per pull-request.
-- Do not include any license information in your examples; our repositories are MIT licensed.
-- Do not submit multiple variations of the same example; demonstrate one thing concisely.
-
-#### Licensing:
-
-- By submitting code to our libraries, you implicitly and irrevocably agree to adopt the associated licenses.
-- You can find licensing information in the LICENSE file.
-
-#### Submitting your Code:
-
-- Be receptive to feedback and be prepared for rejection; we can't always accept contributions.
-- Submit your contribution as a Pull Request.
-
-Thank you for taking the time to read and follow these guidelines.
+- Run pre-commit hooks before submitting (enforces black, isort, commitizen).
+- Keep PRs focused — one feature or fix per PR.
+- Write a clear description of what the change does and why.
+- Do not include license headers; the project is GPL v3.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,34 +1,27 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: "[BUG]"
+about: Report a bug
+title: ''
 labels: bug
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+#### Description:
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+A clear description of the issue and when it occurs.
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+#### Steps to reproduce:
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+The steps required to trigger the behaviour.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. window 10]
- - Python version [e.g python311]
- - Ran from [e.g source, pypi]
- - media filename: [e.g foo.bar.the.movie.2022.1080p-foobar.mkv.]
- - Version [e.g. 22]
+#### Environment:
 
-**Additional context**
-Add any other context about the problem here.
+- OS: <platform>
+- Python version: <python>
+- Filename: <filename.extension>
+- App version: <version>
+
+#### Additional context:
+
+Any other details, logs, or screenshots that may help.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,24 +1,11 @@
 # Security Policy
 
-## Reporting a Security Vulnerability
+## Reporting a Vulnerability
 
-If you believe you have found a security vulnerability, please follow these steps to report it.
+Please do not disclose security issues publicly until they have been addressed.
 
-### Step 1: Do Not Disclose Publicly
-
-Please do not disclose the issue publicly until it has been addressed.
-
-### Step 2: Submitting a Report
-
-- **Option 1 (Preferred):** Submit a report through [security vulnerability submission form](https://github.com/vagabondHustler/subsearch/security/advisories/new).
-- **Option 2:** If you are unable to use the form, you can also email [vagabondHustler](mailto:vagabondhustler.github@gmail.com).
-
-When submitting a report, please include the following information:
-
-- A detailed description of the vulnerability, including steps to reproduce (if applicable).
-- The version of the project in which the vulnerability was discovered.
-- Your name and affiliation (if any).
+Report vulnerabilities via the [GitHub security advisory form](https://github.com/vagabondHustler/subsearch/security/advisories/new). Include a description, steps to reproduce, and the affected version.
 
 ## Supported Versions
 
-Latest stable release and pre-release
+Latest stable release.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     open-pull-requests-limit: 10
     target-branch: "dev"
     labels:
-      - "dependency"
+      - "build"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/automation/operations.py
+++ b/.github/workflows/automation/operations.py
@@ -1,0 +1,492 @@
+"""Reusable operations for the release/maintenance workflows.
+
+Run by file path (`python .github/workflows/automation/workflows.py <name>`) rather
+than as a `-m` module, because `.github` cannot be a Python package. Anything that
+needs the repo root on sys.path relies on the workflow's working directory being the
+checkout root, which GitHub Actions guarantees.
+"""
+
+import hashlib
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPOSITORY_URL = "https://github.com/vagabondHustler/subsearch"
+VIRUSTOTAL_FILE_URL = "https://www.virustotal.com/gui/file"
+
+STYLE_SEPARATOR = "-" * 120
+
+EXE_NAME = "Subsearch.exe"
+HASHES_NAME = "hashes.sha256"
+CHANGELOG_NAME = "changelog.md"
+
+HOME_PATH = Path.home()
+EXE_INSTALLED_PATH = HOME_PATH / "AppData" / "Local" / "Programs" / "Subsearch" / EXE_NAME
+LOG_LOG_PATH = HOME_PATH / "AppData" / "Local" / "Subsearch" / "log.log"
+CONFIG_TOML_PATH = HOME_PATH / "AppData" / "Local" / "Subsearch" / "config.toml"
+
+CWD_PATH = Path.cwd()
+ARTIFACTS_PATH = CWD_PATH / "artifacts"
+DIST_PATH = CWD_PATH / "dist"
+EXE_FREEZE_PATH = CWD_PATH / "build" / f"exe.win-amd64-{sys.version_info[0]}.{sys.version_info[1]}" / EXE_NAME
+HASHES_PATH = ARTIFACTS_PATH / HASHES_NAME
+
+
+APP_NAME = "Subsearch"
+ICON = "src/subsearch/gui/resources/assets/subsearch.ico"
+
+
+def msi_name(version: str) -> str:
+    return f"Subsearch-{version}-win64.msi"
+
+
+def artifact_id(version: str, ref_name: str, run_id: str) -> str:
+    return f"{version}_{ref_name}_{run_id}"
+
+
+def msi_freeze_path() -> Path:
+    candidates = sorted(DIST_PATH.glob("*.msi"))
+    if not candidates:
+        raise FileNotFoundError(f"No .msi found in {DIST_PATH}")
+    return candidates[0]
+
+
+class StepSummary:
+    """Append GitHub Actions step-summary cards: titled sections with a status,
+    rendered as markdown that GitHub displays at the top of each job."""
+
+    CHECK, CROSS = ":heavy_check_mark:", ":x:"
+
+    def set_output(self, name: str, value: str) -> None:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as github_output:
+            print(f"{name}={value}", file=github_output)
+
+    def add_summary(self, text: str) -> None:
+        markdown = str(text).replace("%25", "%").replace("%0D", "\r").replace("%0A", "\n")
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as github_step_summary:
+            github_step_summary.write(f"{markdown}\n")
+
+    def card(self, title: str, passed: bool | None = None) -> None:
+        badge = "" if passed is None else f" {self.CHECK if passed else self.CROSS}"
+        self.add_summary(f"### {title}{badge}")
+
+    def table(self, headers: tuple[str, ...], rows: list[tuple[str, ...]]) -> None:
+        self.add_summary("| " + " | ".join(headers) + " |")
+        self.add_summary("|" + "|".join(["---"] * len(headers)) + "|")
+        for row in rows:
+            self.add_summary("| " + " | ".join(row) + " |")
+
+    def fields(self, items: list[tuple[str, str]]) -> None:
+        for label, value in items:
+            self.add_summary(f"- **{label}:** {value}")
+
+    def emoji(self, flag: bool) -> str:
+        return self.CHECK if flag else self.CROSS
+
+
+class Git:
+    def push_with_tags(self, branch: str) -> None:
+        subprocess.run(["git", "push", "origin", f"HEAD:{branch}", "--follow-tags"], check=True)
+
+    def commit_all(self, message: str) -> None:
+        subprocess.run(["git", "add", "--all"], check=True)
+        subprocess.run(["git", "commit", "--message", message], check=True)
+
+    def push(self, branch: str) -> None:
+        subprocess.run(["git", "push", "origin", f"HEAD:{branch}"], check=True)
+
+    def fetch(self, branch: str, with_tags: bool = False) -> None:
+        command = ["git", "fetch", "origin", branch]
+        if with_tags:
+            command.append("--tags")
+        subprocess.run(command, check=True)
+
+    def fast_forward_branch(self, source_branch: str, target_branch: str) -> None:
+        self.fetch(source_branch, with_tags=True)
+        subprocess.run(["git", "push", "origin", f"origin/{source_branch}:refs/heads/{target_branch}"], check=True)
+
+
+class Commitizen:
+    # Invoked as a module rather than the `cz` console script so the current working
+    # directory is on sys.path and the SubsearchCz plugin (in tools/) is importable.
+    _COMMAND = [sys.executable, "-m", "commitizen"]
+    _TAG_TO_CREATE_PREFIX = "tag to create:"
+
+    def current_version(self) -> str:
+        completed = subprocess.run([*self._COMMAND, "version", "--project"], check=True, capture_output=True, text=True)
+        return completed.stdout.strip()
+
+    def bump_version(self) -> None:
+        # cz bump exits non-zero with NoneIncrementError when no commits warrant a
+        # release; the caller detects that no-op by comparing versions, so the
+        # failure is swallowed here rather than treated as an error.
+        subprocess.run([*self._COMMAND, "bump", "--yes"])
+
+    def predicted_next_version(self) -> str | None:
+        completed = subprocess.run([*self._COMMAND, "bump", "--dry-run", "--yes"], capture_output=True, text=True)
+        if completed.returncode != 0:
+            return None
+        for line in completed.stdout.splitlines():
+            if line.strip().startswith(self._TAG_TO_CREATE_PREFIX):
+                return line.split(self._TAG_TO_CREATE_PREFIX, 1)[1].strip()
+        return None
+
+    def render_changelog_for_tag(self, tag: str, file_name: Path) -> None:
+        subprocess.run([*self._COMMAND, "changelog", tag, "--file-name", str(file_name)], check=True)
+
+    def render_unreleased_changelog(self, unreleased_version: str, file_name: Path) -> None:
+        subprocess.run(
+            [*self._COMMAND, "changelog", "--unreleased-version", unreleased_version, "--file-name", str(file_name)],
+            check=True,
+        )
+
+
+class Changelog:
+    def __init__(self, step_summary: StepSummary) -> None:
+        self._step_summary = step_summary
+
+    def virustotal_link(self, file_name: str, file_hash: str) -> str:
+        return f"[{file_name}]({VIRUSTOTAL_FILE_URL}/{file_hash})"
+
+    def compare_link(self, previous_tag: str, current_tag: str) -> str:
+        return f"[{previous_tag}...{current_tag}]({REPOSITORY_URL}/compare/{previous_tag}...{current_tag})"
+
+    def append_release_links(
+        self,
+        current_tag: str,
+        previous_tag: str,
+        msi_name: str,
+        msi_hash: str,
+        exe_name: str,
+        exe_hash: str,
+    ) -> None:
+        msi_analysis = self.virustotal_link(msi_name, msi_hash)
+        exe_analysis = self.virustotal_link(exe_name, exe_hash)
+        changelog_comparison = self.compare_link(previous_tag, current_tag)
+
+        self._step_summary.card(f"Release {current_tag}")
+        self._step_summary.fields(
+            [
+                ("MSI", msi_analysis),
+                ("Exe", exe_analysis),
+                ("Changelog", changelog_comparison),
+            ]
+        )
+
+        footer = (
+            f"###### VirusTotal: {msi_analysis}<p>VirusTotal: {exe_analysis}"
+            f"<p>Full changelog: {changelog_comparison}"
+        )
+        with open(ARTIFACTS_PATH / CHANGELOG_NAME, "a") as changelog_file:
+            changelog_file.write(footer)
+
+
+class LicenseYear:
+    COPYRIGHT_PATTERN = re.compile(r"Copyright \(C\) (\d{4})(?:-\d{4})? vagabondHustler")
+
+    def current_year(self) -> int:
+        return datetime.now(timezone.utc).year
+
+    def renew_copyright_year(self, license_text: str, year: int) -> str:
+        def replace(match: re.Match[str]) -> str:
+            start_year = int(match.group(1))
+            span = f"{start_year}-{year}" if year > start_year else f"{start_year}"
+            return f"Copyright (C) {span} vagabondHustler"
+
+        return self.COPYRIGHT_PATTERN.sub(replace, license_text, count=1)
+
+    def update_license_file(self, license_path: Path, year: int) -> bool:
+        original = license_path.read_text(encoding="utf-8")
+        renewed = self.renew_copyright_year(original, year)
+        if renewed == original:
+            return False
+        license_path.write_text(renewed, encoding="utf-8", newline="\n")
+        return True
+
+
+def list_files_in_directory(directory: Path) -> None:
+    try:
+        for file in directory.glob("*"):
+            print(file.as_posix())
+    except OSError as error:
+        print(f"Could not list {directory}: {error}")
+
+
+def registry_key_exists() -> bool:
+    import winreg  # Windows-only; imported lazily so this module loads on the Linux CI runner.
+
+    try:
+        with winreg.ConnectRegistry(socket.gethostname(), winreg.HKEY_CURRENT_USER) as hkey:
+            winreg.OpenKey(hkey, r"Software\Classes\*\shell\Subsearch", 0, winreg.KEY_WRITE)
+            return True
+    except FileNotFoundError:
+        return False
+
+
+class BinaryTester:
+    """Install, run, and uninstall the built binary to prove it works end to end."""
+
+    def msi_artifact_path(self) -> Path:
+        candidates = sorted(ARTIFACTS_PATH.glob("*.msi"))
+        if not candidates:
+            raise FileNotFoundError(f"No .msi found in {ARTIFACTS_PATH}")
+        return candidates[0]
+
+    def test_msi_package(self, name: str, msi_package_path: Path) -> None:
+        from subsearch.runtime.version import __version__
+
+        installer_action = {"install": "/i", "uninstall": "/x"}[name]
+        print(f"MSI Package is {name}ing Subsearch {__version__}")
+        subprocess.run(["msiexec.exe", installer_action, str(msi_package_path), "/norestart", "/quiet"], check=True)
+        print(f"{name.capitalize()} completed")
+
+    def is_process_running(self, process_name: str) -> bool:
+        import psutil
+
+        return any(
+            (process.info["name"] or "").lower() == process_name.lower()
+            for process in psutil.process_iter(["pid", "name"])
+        )
+
+    def wait_for_process_start(self, process: "subprocess.Popen", process_name: str, timeout: int = 5) -> None:
+        for _ in range(timeout):
+            if process.poll() is not None:
+                raise RuntimeError(f"{process_name} exited during startup with code {process.returncode}")
+            if self.is_process_running(process_name):
+                return
+            time.sleep(1)
+        raise RuntimeError(f"{process_name} did not start within {timeout} seconds")
+
+    def wait_for_process(self, process: "subprocess.Popen", process_name: str, test_length: int) -> int:
+        import psutil
+
+        for duration in range(test_length + 1):
+            returncode = process.poll()
+            if returncode is not None:
+                raise RuntimeError(f"{process_name} exited early after {duration}s with code {returncode}")
+            try:
+                if psutil.Process(process.pid).status() in (psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD):
+                    raise RuntimeError(f"{process_name} became defunct after {duration}s")
+            except psutil.NoSuchProcess:
+                raise RuntimeError(f"{process_name} vanished after {duration}s")
+            if not self.is_process_running(process_name):
+                return duration
+            time.sleep(1)
+        return test_length
+
+    def end_process(self, process_name: str) -> None:
+        import psutil
+
+        for process in psutil.process_iter(["pid", "name"]):
+            if (process.info["name"] or "").lower() == process_name.lower():
+                print(f"Terminating {process_name}")
+                process.terminate()
+                try:
+                    returncode = process.wait(timeout=10)
+                    print(f"{process_name} terminated with code {returncode}")
+                except psutil.TimeoutExpired:
+                    print(f"{process_name} did not terminate within 10s; killing")
+                    process.kill()
+
+    def window_exists(self, window_title: str) -> bool:
+        import win32gui
+
+        return win32gui.FindWindow(None, window_title) != 0
+
+    def assert_window_rendered(self, window_title: str = APP_NAME, timeout: int = 5) -> None:
+        for _ in range(timeout):
+            if self.window_exists(window_title):
+                print(f"GUI window '{window_title}' is present")
+                return
+            time.sleep(1)
+        raise RuntimeError(f"GUI window '{window_title}' did not appear within {timeout} seconds")
+
+    def _print_file_content(self, file_path: Path) -> None:
+        try:
+            print(file_path.read_text())
+        except OSError as error:
+            print(f"Could not read {file_path}: {error}")
+
+    def expected_files_exists(self) -> None:
+        for path in (LOG_LOG_PATH, CONFIG_TOML_PATH):
+            if not path.parent.exists():
+                list_files_in_directory(path.parent.parent)
+                raise FileNotFoundError(f"Directory '{path.parent}' does not exist.")
+            if not path.is_file():
+                list_files_in_directory(path.parent)
+                raise FileNotFoundError(f"File '{path}' does not exist.")
+            self._print_file_content(path)
+
+    def assert_log_is_clean(self) -> None:
+        log_text = LOG_LOG_PATH.read_text(encoding="utf-8", errors="replace")
+        offending = [line for line in log_text.splitlines() if "ERROR" in line or "CRITICAL" in line]
+        if offending:
+            raise RuntimeError("Log contains ERROR/CRITICAL entries:\n" + "\n".join(offending))
+
+    def test_executable(self, test_length: int = 30) -> None:
+        process_name = EXE_INSTALLED_PATH.name
+        print(f"{process_name} has been initiated for testing")
+        process = subprocess.Popen([EXE_INSTALLED_PATH.as_posix()])
+        self.wait_for_process_start(process, process_name)
+        self.assert_window_rendered()
+        print(f"Waiting {test_length} seconds for process...")
+        duration = self.wait_for_process(process, process_name, test_length)
+        self.expected_files_exists()
+        self.assert_log_is_clean()
+        print(f"{process_name} created expected files")
+        print(f"{process_name} ran for the expected {test_length} seconds")
+        if duration < test_length:
+            raise RuntimeError(f"{process_name} did not run for the expected duration")
+        self.end_process(process_name)
+
+
+class BinaryTestReport:
+    """Render the per-stage install/run/uninstall results as a step-summary card per stage."""
+
+    _PROBES = ("Exe", "Log", "Config", "Registry key")
+
+    # Per stage, the expected presence of (exe, log, config, registry key).
+    _EXPECTED_STATE = {
+        "install": (True, False, False, True),
+        "executable": (True, True, True, True),
+        "uninstall": (False, True, True, False),
+    }
+
+    def __init__(self, step_summary: StepSummary) -> None:
+        self._step_summary = step_summary
+
+    def _current_state(self) -> tuple[bool, bool, bool, bool]:
+        return EXE_INSTALLED_PATH.is_file(), LOG_LOG_PATH.is_file(), CONFIG_TOML_PATH.is_file(), registry_key_exists()
+
+    def add_stage_card(self, name: str) -> None:
+        actual = self._current_state()
+        expected = self._EXPECTED_STATE[name]
+        passed = actual == expected
+
+        rows = [
+            (probe, self._step_summary.emoji(is_present), self._step_summary.emoji(should_exist))
+            for probe, is_present, should_exist in zip(self._PROBES, actual, expected)
+        ]
+        self._step_summary.card(f"{name.capitalize()} test", passed=passed)
+        self._step_summary.table(("Probe", "Found", "Expected"), rows)
+
+        self._log_stage(name, actual, passed)
+        if not passed:
+            list_files_in_directory(EXE_INSTALLED_PATH.parent)
+            list_files_in_directory(LOG_LOG_PATH.parent)
+            raise RuntimeError(f"{name} test failed")
+
+    def _log_stage(self, name: str, actual: tuple[bool, bool, bool, bool], passed: bool) -> None:
+        print("")
+        print(", ".join(f"{probe}: {present}" for probe, present in zip(self._PROBES, actual)))
+        print(f"{name.capitalize()} test {'passed' if passed else 'failed'}")
+        print(STYLE_SEPARATOR)
+
+
+class ArtifactHasher:
+    """Collect the frozen msi/exe into ./artifacts and record their sha256 hashes."""
+
+    def __init__(self, step_summary: StepSummary) -> None:
+        self._step_summary = step_summary
+
+    def calculate_sha256(self, file_path: Path) -> str:
+        if not file_path.is_file():
+            raise FileNotFoundError(f"No file found at {file_path}")
+        sha256_hash = hashlib.sha256()
+        with open(file_path, "rb") as file:
+            for byte_block in iter(lambda: file.read(4096), b""):
+                sha256_hash.update(byte_block)
+        return sha256_hash.hexdigest()
+
+    def prepare_build_artifacts(self) -> None:
+        print("Collecting files")
+        ARTIFACTS_PATH.mkdir(parents=True, exist_ok=True)
+        for file in (msi_freeze_path(), EXE_FREEZE_PATH):
+            file.replace(ARTIFACTS_PATH / file.name)
+            print(f"{file.name} moved to ./artifacts")
+
+    def write_to_hashes(self) -> None:
+        print("Collecting hashes")
+        ARTIFACTS_PATH.mkdir(parents=True, exist_ok=True)
+
+        hashes = {file_path: self.calculate_sha256(file_path) for file_path in (msi_freeze_path(), EXE_FREEZE_PATH)}
+
+        for file_path, sha256 in hashes.items():
+            output_name = f"{file_path.suffix[1:]}_hash"
+            print(f"Setting new Github Action output: {output_name}={sha256}")
+            self._step_summary.set_output(output_name, sha256)
+
+        self._step_summary.card("Build artifacts")
+        self._step_summary.table(
+            ("File", "SHA256"),
+            [(file_path.name, f"`{sha256}`") for file_path, sha256 in hashes.items()],
+        )
+
+        print(f"Writing to {HASHES_PATH.name}")
+        with open(HASHES_PATH, "w") as file:
+            file.writelines(f"{sha256} *{file_path.name}\n" for file_path, sha256 in hashes.items())
+
+
+class Build:
+    """Freeze the app into an exe and package it as a Windows msi via cx_Freeze."""
+
+    _LIBS_TO_EXCLUDE = [
+        "concurrent",
+        "lib2to3",
+        "multiprocessing",
+        "distutils",
+        "tcl8",
+        "test",
+        "unittest",
+        "xml",
+        "xmlrpc",
+        "asyncio",
+        "chardet",
+    ]
+
+    def _data_table(self) -> dict:
+        script_component = f"_cx_executable0__Executable_script_src_{APP_NAME.lower()}___main__.py_"
+        registry_path = r"Software\Classes\*\shell\Subsearch"
+        return {
+            "Registry": {
+                (f"{APP_NAME}_key", -1, registry_path, None, None, script_component),
+                (f"{APP_NAME}_regz_icon", -1, registry_path, "Icon", None, script_component),
+                (f"{APP_NAME}_regz_appliesto", -1, registry_path, "AppliesTo", None, script_component),
+                (f"{APP_NAME}_key_command", -1, rf"{registry_path}\command", None, "", script_component),
+            },
+        }
+
+    def _executables(self) -> list:
+        from cx_Freeze import Executable
+
+        return [
+            Executable(
+                "src/subsearch/__main__.py",
+                base="Win32GUI",
+                target_name=APP_NAME,
+                icon=ICON,
+                shortcut_name="Subsearch",
+                shortcut_dir="ProgramMenuFolder",
+            )
+        ]
+
+    def _options(self) -> dict:
+        from subsearch.runtime.guid import __guid__
+
+        bdist_msi = {"upgrade_code": f"{__guid__}", "install_icon": ICON, "data": self._data_table()}
+        license_files = [("LICENSE", "LICENSE"), ("THIRD-PARTY-LICENSES.md", "THIRD-PARTY-LICENSES.md")]
+        build_exe = {"excludes": [*self._LIBS_TO_EXCLUDE], "include_files": license_files}
+        return {"build_exe": build_exe, "bdist_msi": bdist_msi}
+
+    def make_msi(self) -> None:
+        # cx_Freeze's setup() reads the command from sys.argv, so set it explicitly
+        # rather than depending on how this script was invoked.
+        from cx_Freeze import setup
+
+        sys.argv = [sys.argv[0], "bdist_msi"]
+        setup(options=self._options(), executables=self._executables())

--- a/.github/workflows/automation/workflows.py
+++ b/.github/workflows/automation/workflows.py
@@ -1,0 +1,285 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import operations
+from operations import (
+    ARTIFACTS_PATH,
+    CHANGELOG_NAME,
+    CWD_PATH,
+    EXE_NAME,
+    ArtifactHasher,
+    BinaryTester,
+    BinaryTestReport,
+    Build,
+    Changelog,
+    Commitizen,
+    Git,
+    LicenseYear,
+    StepSummary,
+)
+
+LICENSE_PATH = CWD_PATH / "LICENSE"
+
+
+class Init:
+    def run(self) -> None:
+        ref_name = os.environ["GITHUB_REF_NAME"]
+        run_id = os.environ["GITHUB_RUN_ID"]
+
+        commitizen = Commitizen()
+        step_summary = StepSummary()
+
+        previous_version = commitizen.current_version()
+        commitizen.bump_version()
+        current_version = commitizen.current_version()
+
+        bumped = current_version != previous_version
+        step_summary.set_output("bumped", "true" if bumped else "false")
+
+        if not bumped:
+            return
+
+        identifier = operations.artifact_id(current_version, ref_name, run_id)
+        step_summary.set_output("current_tag", current_version)
+        step_summary.set_output("previous_tag", previous_version)
+        step_summary.set_output("msi_name", operations.msi_name(current_version))
+        step_summary.set_output("artifact_id", identifier)
+
+        Git().push_with_tags(ref_name)
+
+
+class MakeMsi:
+    def run(self) -> None:
+        Build().make_msi()
+
+
+class BuildBinaries:
+    def run(self) -> None:
+        hasher = ArtifactHasher(StepSummary())
+        hasher.write_to_hashes()
+        hasher.prepare_build_artifacts()
+
+
+class TestBinaries:
+    def run(self) -> None:
+        tester = BinaryTester()
+        report = BinaryTestReport(StepSummary())
+        self._run_msi(tester, report, "install")
+        self._run_exe(tester, report)
+        self._run_msi(tester, report, "uninstall")
+
+    def _run_msi(self, tester: BinaryTester, report: BinaryTestReport, flag: str) -> None:
+        tester.test_msi_package(flag, tester.msi_artifact_path())
+        report.add_stage_card(flag)
+
+    def _run_exe(self, tester: BinaryTester, report: BinaryTestReport) -> None:
+        tester.test_executable(30)
+        report.add_stage_card("executable")
+
+
+class BuildChangelog:
+    def run(self) -> None:
+        ref_name = os.environ["GITHUB_REF_NAME"]
+        current_tag = os.environ["CURRENT_TAG"]
+        previous_tag = os.environ["PREVIOUS_TAG"]
+        msi_name = os.environ["MSI_NAME"]
+        msi_hash = os.environ["MSI_HASH"]
+        exe_hash = os.environ["EXE_HASH"]
+
+        commitizen = Commitizen()
+        changelog = Changelog(StepSummary())
+
+        ARTIFACTS_PATH.mkdir(parents=True, exist_ok=True)
+        Git().fetch(ref_name, with_tags=True)
+        commitizen.render_changelog_for_tag(current_tag, ARTIFACTS_PATH / CHANGELOG_NAME)
+
+        changelog.append_release_links(
+            current_tag=current_tag,
+            previous_tag=previous_tag,
+            msi_name=msi_name,
+            msi_hash=msi_hash,
+            exe_name=EXE_NAME,
+            exe_hash=exe_hash,
+        )
+
+
+class Prepare:
+    def run(self) -> None:
+        ref_name = os.environ["GITHUB_REF_NAME"]
+
+        commitizen = Commitizen()
+        changelog = Changelog(StepSummary())
+        step_summary = StepSummary()
+
+        predicted_version = commitizen.predicted_next_version()
+        step_summary.set_output("releasable", "true" if predicted_version else "false")
+
+        if predicted_version is None:
+            return
+
+        current_version = commitizen.current_version()
+        step_summary.set_output("predicted_version", predicted_version)
+
+        ARTIFACTS_PATH.mkdir(parents=True, exist_ok=True)
+        Git().fetch(ref_name, with_tags=True)
+        commitizen.render_unreleased_changelog(predicted_version, ARTIFACTS_PATH / CHANGELOG_NAME)
+
+        with open(ARTIFACTS_PATH / CHANGELOG_NAME, "a") as changelog_file:
+            comparison = changelog.compare_link(previous_tag=current_version, current_tag=predicted_version)
+            changelog_file.write(f"###### Full changelog: {comparison}")
+
+
+class OpenMainPullRequest:
+    RELEASE_LABEL = "release"
+    SOURCE_BRANCH = "dev"
+    TARGET_BRANCH = "main"
+    OWNER = "vagabondHustler"
+
+    def run(self) -> None:
+        import subprocess
+
+        predicted_version = os.environ["PREDICTED_VERSION"]
+        title = f"Release {predicted_version}"
+        body = (ARTIFACTS_PATH / CHANGELOG_NAME).read_text()
+
+        pull_request_number = self._existing_pull_request_number()
+        if pull_request_number:
+            subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "edit",
+                    pull_request_number,
+                    "--title",
+                    title,
+                    "--body",
+                    body,
+                    "--add-assignee",
+                    self.OWNER,
+                    "--add-reviewer",
+                    self.OWNER,
+                ],
+                check=True,
+            )
+            return
+
+        subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--base",
+                self.TARGET_BRANCH,
+                "--head",
+                self.SOURCE_BRANCH,
+                "--title",
+                title,
+                "--body",
+                body,
+                "--label",
+                self.RELEASE_LABEL,
+                "--assignee",
+                self.OWNER,
+                "--reviewer",
+                self.OWNER,
+            ],
+            check=True,
+        )
+
+    def _existing_pull_request_number(self) -> str | None:
+        import subprocess
+
+        completed = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--base",
+                self.TARGET_BRANCH,
+                "--head",
+                self.SOURCE_BRANCH,
+                "--state",
+                "open",
+                "--json",
+                "number",
+                "--jq",
+                ".[0].number",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        number = completed.stdout.strip()
+        return number or None
+
+
+class DryRunInit:
+    def run(self) -> None:
+        ref_name = os.environ["GITHUB_REF_NAME"]
+        run_id = os.environ["GITHUB_RUN_ID"]
+
+        commitizen = Commitizen()
+        step_summary = StepSummary()
+
+        previous_version = commitizen.current_version()
+        predicted_version = commitizen.predicted_next_version()
+
+        if predicted_version is None:
+            step_summary.set_output("bumped", "false")
+            return
+
+        identifier = operations.artifact_id(predicted_version, ref_name, run_id)
+        step_summary.set_output("bumped", "true")
+        step_summary.set_output("current_tag", predicted_version)
+        step_summary.set_output("previous_tag", previous_version)
+        step_summary.set_output("msi_name", operations.msi_name(predicted_version))
+        step_summary.set_output("artifact_id", identifier)
+
+
+class SyncDev:
+    def run(self) -> None:
+        release_branch = os.environ["GITHUB_REF_NAME"]
+        Git().fast_forward_branch(source_branch=release_branch, target_branch="dev")
+
+
+class UpdateLicenseYear:
+    def run(self) -> None:
+        release_branch = os.environ["GITHUB_REF_NAME"]
+        license_year = LicenseYear()
+        git = Git()
+
+        year = license_year.current_year()
+        if not license_year.update_license_file(LICENSE_PATH, year):
+            return
+
+        git.commit_all(f"chore(license): renew copyright year to {year}")
+        git.push(release_branch)
+        git.fast_forward_branch(source_branch=release_branch, target_branch="dev")
+
+
+JOBS = {
+    "init": Init,
+    "dry_run_init": DryRunInit,
+    "make_msi": MakeMsi,
+    "build_binaries": BuildBinaries,
+    "test_binaries": TestBinaries,
+    "changelog": BuildChangelog,
+    "prepare": Prepare,
+    "open_main_pr": OpenMainPullRequest,
+    "sync_dev": SyncDev,
+    "update_license_year": UpdateLicenseYear,
+}
+
+
+def main() -> None:
+    if len(sys.argv) != 2 or sys.argv[1] not in JOBS:
+        available = ", ".join(sorted(JOBS))
+        raise SystemExit(f"usage: workflows.py <job>\navailable jobs: {available}")
+    JOBS[sys.argv[1]]().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   dependency_review:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -16,24 +16,11 @@ jobs:
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v4
 
-  pr_labeler:
-    runs-on: windows-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Auto label
-        uses: TimonVS/pr-labeler-action@v5
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: .github/configs/labeler.yml
 
   paths_filter:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     outputs:
       src: "${{ steps.filter.outputs.src }}"
-      tests: "${{ steps.filter.outputs.tests }}"
-      tools: "${{ steps.filter.outputs.tools }}"
     steps:
       - uses: actions/checkout@v4
 
@@ -44,25 +31,18 @@ jobs:
           filters: |
             src:
               - "src/**"
-            tests:
-              - "tests/**"
-            tools:
-              - "tools/**"
+              - "assets/**"
 
   tox:
     needs: paths_filter
     if: ${{ needs.paths_filter.outputs.src == 'true' }}
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ["3.12.*"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version-file: .python-version
 
       - name: Install dependencies
         run: |
@@ -72,42 +52,19 @@ jobs:
       - name: Run tests
         run: tox
 
+
   lint:
     needs: paths_filter
-    if: ${{ needs.paths_filter.outputs.src == 'true' || needs.paths_filter.outputs.tests == 'true' || needs.paths_filter.outputs.tools == 'true'}}
+    if: ${{ needs.paths_filter.outputs.src == 'true' }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+      - uses: actions/setup-python@v5
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_config_global: true
+          python-version-file: .python-version
 
-      - name: Lint codebase
+      - name: Run pre-commit hooks
         run: |
-          pip install black isort
-          isort ./src ./tests ./tools --profile 'black'
-          black ./src ./tests ./tools -l 125
-
-      - name: Check for changes
-        id: git_status
-        run: |
-          $gitStatus = git status --porcelain
-          if ($gitStatus) {
-              $changes="true"
-          } else {
-              $changes="false"
-          }
-
-      - name: Commit and push
-        if: ${{ steps.git_status.outputs.changes == 'true' }}
-        run: |
-          git add -A
-          git commit -S -m "Reformat codebase with black & isort"
-          git fetch origin main
-          git push origin HEAD:main
+          python -m pip install --upgrade pip pre-commit
+          pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL security analysis
+run-name: CodeQL security analysis
+
+# Weekly (Sundays 03:00 UTC): run CodeQL security analysis on the Python source.
+
+on:
+  schedule:
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize Codeql
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+
+    - uses: github/codeql-action/autobuild@v3
+
+    - uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -1,0 +1,154 @@
+name: Dry run release
+run-name: Dry run release
+
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_binary_tests:
+        description: "Skip binary install/run/uninstall tests"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dry-run-release-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  ARTIFACT_RETENTION_DAYS: 3
+
+jobs:
+  init:
+    name: Version control (dry run)
+    runs-on: windows-latest
+    timeout-minutes: 10
+    outputs:
+      bumped: ${{ steps.run.outputs.bumped }}
+      current_tag: ${{ steps.run.outputs.current_tag }}
+      previous_tag: ${{ steps.run.outputs.previous_tag }}
+      msi_name: ${{ steps.run.outputs.msi_name }}
+      artifact_id: ${{ steps.run.outputs.artifact_id }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Install commitizen
+        run: |
+          python -m pip install --upgrade pip commitizen
+          python -m pip install -e . --no-deps
+
+      - name: Set fake version outputs (no bump, no push)
+        id: run
+        run: python .github/workflows/automation/workflows.py dry_run_init
+
+  build_binaries:
+    name: Build binaries
+    needs: init
+    runs-on: windows-latest
+    timeout-minutes: 10
+    outputs:
+      msi_hash: ${{ steps.run.outputs.msi_hash }}
+      exe_hash: ${{ steps.run.outputs.exe_hash }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Build binaries
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[build]
+          python .github/workflows/automation/workflows.py make_msi
+
+      - name: Hash and collect artifacts
+        id: run
+        run: python .github/workflows/automation/workflows.py build_binaries
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_${{ needs.init.outputs.artifact_id }}
+          path: artifacts
+          if-no-files-found: error
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+  test_binaries:
+    name: Test binaries
+    needs: [init, build_binaries]
+    if: ${{ inputs.skip_binary_tests == 'false' }}
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: build_${{ needs.init.outputs.artifact_id }}
+          path: artifacts
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip psutil pywin32
+          python -m pip install -e . --no-deps
+
+      - run: python .github/workflows/automation/workflows.py test_binaries
+
+  changelog:
+    name: Changelog
+    needs: [init, build_binaries]
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Install commitizen
+        run: |
+          python -m pip install --upgrade pip commitizen
+          python -m pip install -e . --no-deps
+
+      - name: Render changelog and append links
+        run: python .github/workflows/automation/workflows.py changelog
+        env:
+          CURRENT_TAG: ${{ needs.init.outputs.current_tag }}
+          PREVIOUS_TAG: ${{ needs.init.outputs.previous_tag }}
+          MSI_NAME: ${{ needs.init.outputs.msi_name }}
+          MSI_HASH: ${{ needs.build_binaries.outputs.msi_hash }}
+          EXE_HASH: ${{ needs.build_binaries.outputs.exe_hash }}
+
+      - name: Upload changelog artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog_${{ needs.init.outputs.artifact_id }}
+          path: artifacts
+          if-no-files-found: error
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,47 @@
+name: Prepare release
+run-name: Prepare release ${{ github.ref_name }}
+
+
+on:
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: prepare-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  open_main_pr:
+    name: Open pull request to main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Install commitizen
+        run: |
+          python -m pip install --upgrade pip commitizen
+          python -m pip install -e . --no-deps
+
+      - name: Render preview changelog
+        id: preview
+        run: python .github/workflows/automation/workflows.py prepare
+
+      - name: Open or update the release pull request
+        if: ${{ steps.preview.outputs.releasable == 'true' }}
+        run: python .github/workflows/automation/workflows.py open_main_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREDICTED_VERSION: ${{ steps.preview.outputs.predicted_version }}

--- a/.github/workflows/provider-healthcheck.yml
+++ b/.github/workflows/provider-healthcheck.yml
@@ -1,0 +1,30 @@
+name: Provider health check
+run-name: Provider health check
+
+#   Monthly (1st, 03:00 UTC) and on demand:
+#   hits each subtitle provider with a known-good title and fails if one
+#   returns nothing or an unrecognized response — an early warning that a
+#   provider changed its site or API before users are affected.
+
+on:
+  schedule:
+    - cron: '0 3 1 * *'
+  workflow_dispatch:
+
+jobs:
+  diagnose:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Run provider diagnostics
+        run: python -m subsearch.providers.diagnostics

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,93 +1,35 @@
 name: Release
-run-name: Release ${{ inputs.new_tags }}
+run-name: Release ${{ github.ref_name }}
+
 
 on:
-  workflow_dispatch:
-    inputs:
-      new_tags:
-        description: "Release version."
-        type: string
-        required: true
-      python_version:
-        description: "Python version to use when building binaries."
-        type: string
-        required: false
-        default: "3.12"
-      artifact_retention_days:
-        description: "Number of days to retain build artifacts in GitHub Actions."
-        type: number
-        required: false
-        default: 7
-      timeout_minutes:
-        description: "Timeout in minutes for jobs in GitHub Actions."
-        type: number
-        required: false
-        default: 10
-      runs_on:
-        description: "GitHub Actions runner environment for jobs in the workflow."
-        type: string
-        required: false
-        default: windows-latest
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
-  CLI: python -m tools.github_actions.cli.commands
-  NEW_VERSION: ${{ inputs.new_tags }}
-  ID: "${{ inputs.new_tags }}_${{ github.ref_name }}_${{ github.run_id }}"
-  VERSION_CONTROL_PATH: ".github/configs/version_control.json"
-  VERSION_PY_PATH: "src/subsearch/data/version.py"
-  MSI_NAME: "Subsearch-${{ inputs.new_tags }}-win64.msi"
-  EXE_NAME: "Subsearch.exe"
-  HASHES_NAME: "hashes.sha256"
-  CHANGELOG_NAME: "changelog.md"
+  ARTIFACT_RETENTION_DAYS: 7
 
 jobs:
   init:
-    name: Initializing environments
-    runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes)}} # fromJson because https://github.com/orgs/community/discussions/55332#discussioncomment-5887877
-    outputs:
-      current_tags: "${{ steps.current_tags.outputs.tags }}"
-      previous_tags: "${{ steps.previous_tags.outputs.tags }}"
-      last_stable_release: "${{ steps.last_stable_release.outputs.tags }}"
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref_name }}
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "*"
-
-      - name: Validate that the tags are new
-        run: git tag ${{ inputs.new_tags }}
-
-      - name: Validate inputs
-        id: valid_inputs
-        run: >
-          ${{ env.CLI }} init 
-          --validate-inputs 
-          "new_tags=${{ inputs.new_tags }};
-          python_version=${{ inputs.python_version }};
-          checkout_branch=${{ github.ref_name }}"
-
-      - name: Current tags
-        id: current_tags
-        run: ${{ env.CLI }} json --read current_version # tags=value
-
-      - name: Previous stable tags
-        id: last_stable_release
-        run: ${{ env.CLI }} json --read last_stable_release # tags=value
-
-      - name: Previous tags
-        id: previous_tags
-        run: ${{ env.CLI }} json --read previous_version # tags=value
-
-  version_control:
     name: Version control
-    needs: init
-    runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes)}}
+    if: ${{ !startsWith(github.event.head_commit.message, 'bump:') && !startsWith(github.event.head_commit.message, 'chore(license):') }}
+    runs-on: windows-latest
+    timeout-minutes: 10
+    outputs:
+      bumped: ${{ steps.run.outputs.bumped }}
+      current_tag: ${{ steps.run.outputs.current_tag }}
+      previous_tag: ${{ steps.run.outputs.previous_tag }}
+      msi_name: ${{ steps.run.outputs.msi_name }}
+      artifact_id: ${{ steps.run.outputs.artifact_id }}
     steps:
       - uses: crazy-max/ghaction-import-gpg@v6
         with:
@@ -100,54 +42,31 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "*"
+          python-version-file: .python-version
 
-      - name: Get previous version
-        id: version
-        run: ${{ env.CLI}} python --read-string # version=value
-
-      - name: Create new tags
-        if: ${{ !contains(inputs.new_tags, 'dev') }}
-        run: git tag -a ${{ inputs.new_tags }} -m "Release ${{ inputs.new_tags }}"
-
-      - name: Bump subsearch version
-        run: ${{ env.CLI}} python --write-string ${{ inputs.new_tags }}
-
-      - name: Bump current version
-        run: ${{ env.CLI }} json -w current_version ${{ inputs.new_tags }}
-
-      - name: Bump previous version
-        run: ${{ env.CLI }} json -w previous_version ${{ needs.init.outputs.current_tags }}
-
-      - name: Bump last stable release
-        if: ${{ !contains(inputs.new_tags, 'dev')  }}
-        run: ${{ env.CLI }} json -w last_stable_release ${{ inputs.new_tags }}
-
-      - name: Push commits
+      - name: Install commitizen
         run: |
-          git status
-          git fetch origin ${{ github.ref_name }}
-          git add ${{ env.VERSION_PY_PATH }} ${{ env.VERSION_CONTROL_PATH }} 
-          git commit -S -m "Bump version to ${{ inputs.new_tags }}"
-          git push origin HEAD:${{ github.ref_name }}
+          python -m pip install --upgrade pip commitizen
+          python -m pip install -e . --no-deps
 
-      - name: Push tags
-        if: ${{ !contains(inputs.new_tags, 'dev')  }}
-        run: |
-          git push origin --tags
+      - name: Bump version, tag, and push
+        id: run
+        run: python .github/workflows/automation/workflows.py init
 
   build_binaries:
     name: Build binaries
-    needs: [init, version_control]
-    runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
+    needs: init
+    if: ${{ needs.init.outputs.bumped == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 10
     outputs:
-      msi_hash: ${{ steps.hashes.outputs.msi_hash }}
-      exe_hash: ${{ steps.hashes.outputs.exe_hash }}
-
+      msi_hash: ${{ steps.run.outputs.msi_hash }}
+      exe_hash: ${{ steps.run.outputs.exe_hash }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -155,36 +74,33 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ inputs.python_version }}
+          python-version-file: .python-version
 
       - name: Build binaries
-        id: build
         run: |
           git fetch origin ${{ github.ref_name }}
           python -m pip install --upgrade pip
           pip install -e .[build]
-          python -m tools.build bdist_msi
+          python .github/workflows/automation/workflows.py make_msi
 
-      - name: Create hashes file and set outputs
-        id: hashes
-        run: ${{ env.CLI }} binaries --write-hash # suffix_hash=value
-
-      - name: Prepare artifacts
-        run: ${{ env.CLI }} binaries --prepare-build-artifacts
+      - name: Hash and collect artifacts
+        id: run
+        run: python .github/workflows/automation/workflows.py build_binaries
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build_${{ env.ID }}
+          name: build_${{ needs.init.outputs.artifact_id }}
           path: artifacts
           if-no-files-found: error
-          retention-days: ${{ inputs.artifact_retention_days }}
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
   test_binaries:
     name: Test binaries
-    needs: [init, version_control, build_binaries]
-    runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
+    needs: [init, build_binaries]
+    if: ${{ needs.init.outputs.bumped == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -192,40 +108,35 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "*"
+          python-version-file: .python-version
 
       - uses: actions/download-artifact@v4
-        id: download
         with:
-          name: build_${{ env.ID }}
+          name: build_${{ needs.init.outputs.artifact_id }}
           path: artifacts
 
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: ${{ steps.download.outputs.download-path }}
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip psutil pywin32
+          python -m pip install -e . --no-deps
 
-      - run: python -m tools.github_actions.jobs.test_binaries
+      - run: python .github/workflows/automation/workflows.py test_binaries
 
   upload_binaries:
     name: Upload binaries to virustotal
-    if: ${{  !contains(inputs.new_tags, 'dev') }}
     needs: [init, build_binaries]
-    runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes)}}
+    if: ${{ needs.init.outputs.bumped == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
 
       - uses: actions/download-artifact@v4
-        id: download
         with:
-          name: build_${{ env.ID }}
+          name: build_${{ needs.init.outputs.artifact_id }}
           path: artifacts
-
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: ${{ steps.download.outputs.download-path }}
 
       - uses: crazy-max/ghaction-virustotal@v4
         with:
@@ -234,133 +145,79 @@ jobs:
           update_release_body: false
           request_rate: 4
           files: |
-            artifacts/${{ env.EXE_NAME }}
-            artifacts/${{ env.MSI_NAME }}
+            artifacts/Subsearch.exe
+            artifacts/${{ needs.init.outputs.msi_name }}
 
   changelog:
     name: Changelog
-    if: ${{ !contains(inputs.new_tags, 'dev') }}
     needs: [init, build_binaries]
-    runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes)}}
+    if: ${{ needs.init.outputs.bumped == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+          fetch-depth: 0
 
-      - name: Build
-        id: build
-        uses: mikepenz/release-changelog-builder-action@v5
+      - uses: actions/setup-python@v5
         with:
-          fromTag: ${{ needs.init.outputs.last_stable_release }}
-          toTag: ${{ inputs.new_tags }}
-          configuration: .github/configs/changelog_builder.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          python-version-file: .python-version
 
-      - name: Create markdown
+      - name: Install commitizen
         run: |
-          mkdir "artifacts"
-          echo "${{ steps.build.outputs.changelog }}" > artifacts/${{ env.CHANGELOG_NAME }}
+          python -m pip install --upgrade pip commitizen
+          python -m pip install -e . --no-deps
 
-      - name: Update
-        run: >
-          ${{ env.CLI }} changelog
-          --tags "${{ inputs.new_tags }};${{ needs.init.outputs.last_stable_release }}"
-          --file-names "${{ env.MSI_NAME }};${{ env.EXE_NAME }}"
-          --hashes "${{ needs.build_binaries.outputs.msi_hash }};${{ needs.build_binaries.outputs.exe_hash }}"
+      - name: Render changelog and append links
+        run: python .github/workflows/automation/workflows.py changelog
+        env:
+          CURRENT_TAG: ${{ needs.init.outputs.current_tag }}
+          PREVIOUS_TAG: ${{ needs.init.outputs.previous_tag }}
+          MSI_NAME: ${{ needs.init.outputs.msi_name }}
+          MSI_HASH: ${{ needs.build_binaries.outputs.msi_hash }}
+          EXE_HASH: ${{ needs.build_binaries.outputs.exe_hash }}
 
       - name: Upload changelog artifact
         uses: actions/upload-artifact@v4
         with:
-          name: changelog_${{ env.ID }}
+          name: changelog_${{ needs.init.outputs.artifact_id }}
           path: artifacts
           if-no-files-found: error
-          retention-days: ${{ inputs.artifact_retention_days }}
-
-  update_main:
-    name: Create pull request and update main
-    if: ${{ !contains(inputs.new_tags, 'dev') }}
-    needs: [init, test_binaries, changelog]
-    runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_config_global: true
-
-      - uses: actions/download-artifact@v4
-        id: download
-        with:
-          path: artifacts
-
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: ${{ steps.download.outputs.download-path }}
-
-      - name: Create PR
-        run: |
-          $changelogTitle = "Release ${{ inputs.new_tags }}"
-          $changelogBody = Get-Content -Raw "artifacts\changelog_${{ env.ID }}\${{ env.CHANGELOG_NAME }}"
-          git fetch --all
-          gh pr create -B main -H dev -t "$changelogTitle" -b "$changelogBody" -l "release"
-          gh pr merge -m
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
   publish_github:
     name: Publish to github
-    if: ${{ !contains(inputs.new_tags, 'dev') }}
-    needs: [init, test_binaries, changelog, update_main]
-    runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes)}}
+    needs: [init, test_binaries, changelog]
+    if: ${{ needs.init.outputs.bumped == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 10
     steps:
-      - uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_config_global: true
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
 
       - uses: actions/download-artifact@v4
-        id: download
         with:
           path: artifacts
 
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: ${{ steps.download.outputs.download-path }}
-
       - uses: softprops/action-gh-release@v2
         with:
-          name: ${{ inputs.new_tags }}
-          tag_name: ${{ inputs.new_tags }}
-          body_path: artifacts/changelog_${{ env.ID }}/${{ env.CHANGELOG_NAME }}
+          name: ${{ needs.init.outputs.current_tag }}
+          tag_name: ${{ needs.init.outputs.current_tag }}
+          body_path: artifacts/changelog_${{ needs.init.outputs.artifact_id }}/changelog.md
           token: ${{ secrets.ACTIONS_TOKEN }}
-          prerelease: ${{ contains(inputs.new_tags, 'dev') }}
+          prerelease: false
           files: |
-            artifacts/build_${{ env.ID }}/${{ env.HASHES_NAME }}
-            artifacts/build_${{ env.ID }}/${{ env.MSI_NAME }}
+            artifacts/build_${{ needs.init.outputs.artifact_id }}/hashes.sha256
+            artifacts/build_${{ needs.init.outputs.artifact_id }}/${{ needs.init.outputs.msi_name }}
 
   publish_pypi:
     name: Publish to pypi
-    if: ${{ !contains(inputs.new_tags, 'dev') }}
-    needs: [version_control, test_binaries, update_main]
-    runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
+    needs: [init, test_binaries]
+    if: ${{ needs.init.outputs.bumped == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -368,49 +225,36 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ inputs.python_version }}
+          python-version-file: .python-version
 
-      - name: Install requirements
+      - name: Install build and twine
         run: |
           git fetch origin ${{ github.ref_name }}
-          python -m pip install --upgrade --disable-pip-version-check pip
-          python -m pip install --upgrade build twine
+          python -m pip install --upgrade --disable-pip-version-check pip build twine
 
       - name: Build wheel and source distributions
-        run: |
-          python -m build
+        run: python -m build
 
       - name: Upload to pypi
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          twine upload --verbose -u '__token__' dist/*
+        run: twine upload --verbose -u '__token__' dist/*
 
+  sync_dev:
+    name: Fast-forward dev to main
+    needs: [init, publish_github, publish_pypi]
+    if: ${{ needs.init.outputs.bumped == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-  # sync_dev:
-  #   name: Synchronize dev with main
-  #   if: ${{ !contains(inputs.new_tags, 'dev') }}
-  #   needs: [init, publish_pypi, publish_github]
-  #   runs-on: ${{ inputs.runs_on }}
-  #   timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-
-  #     - uses: crazy-max/ghaction-import-gpg@v6
-  #       with:
-  #         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-  #         passphrase: ${{ secrets.GPG_PASSPHRASE }}
-  #         git_user_signingkey: true
-  #         git_commit_gpgsign: true
-  #         git_config_global: true
-
-
-  #     - name: Synchronize dev with main
-  #       run: |
-  #         git fetch --all
-  #         git checkout dev
-  #         git rebase main
-  #         git push origin dev --force-with-lease
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: python .github/workflows/automation/workflows.py sync_dev

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: Stale issues and pull requests
+run-name: Stale issues and pull requests
+
+# Weekly (Mondays 03:00 UTC): mark inactive issues/PRs stale and close them.
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/stale@v9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 60
+        days-before-close: 6
+        stale-issue-message: 'No activity in the last 60 days. Marking as stale; will close in 7 days without further activity.'
+        stale-pr-message: 'No activity in the last 60 days. Marking as stale; will close in 7 days without further activity.'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        exempt-issue-labels: 'keep open'
+        exempt-pr-labels: 'keep open,build,ci,release'

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -1,0 +1,42 @@
+name: Update license year
+run-name: Update license year
+
+# Renews the copyright year in LICENSE on January 1st (00:00 UTC) and keeps
+# dev in sync with main. The chore(license) commit is ignored by the release
+# pipeline, so it never triggers a version bump or release.
+
+on:
+  schedule:
+    - cron: '0 0 1 1 *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-license-year
+  cancel-in-progress: false
+
+jobs:
+  renew_year:
+    name: Renew copyright year
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Renew year and sync dev
+        run: python .github/workflows/automation/workflows.py update_license_year


### PR DESCRIPTION
## Summary
- Brings `.github/` on `main` up to date with `dev`
- Adds missing workflows (`dry-run-release`, `prepare-release`, `provider-healthcheck`, `codeql`, `stale`, `update-license-year`) and automation scripts so `workflow_dispatch` triggers are discoverable in Actions
- Temporary: `main` will be replaced by `dev` soon; this unblocks workflow testing in the meantime